### PR TITLE
feat: expose DebugBridge runtime endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An **MCP (Model Context Protocol) server** that empowers AI coding agents to wor
 
 ### Static Analysis (work offline)
 - **Decompiled Source Access** — Auto-downloads and decompiles Minecraft client using [Vineflower](https://github.com/Vineflower/vineflower)
-- **Dev Snapshot Support** — Works with development snapshots (e.g., `26.1-snapshot-10`) that lack ProGuard mappings
+- **Dev Snapshot Support** — Works with development snapshots (e.g., `26.2-snapshot-4`, `26w14a`) that lack ProGuard mappings
 - **Symbol Search** — Search for classes, methods, and fields by name (`mc_search`)
 - **Source Retrieval** — Get full class source or individual methods with context
 - **Package Exploration** — List all classes under a package path or discover available packages
@@ -22,6 +22,7 @@ An **MCP (Model Context Protocol) server** that empowers AI coding agents to wor
 - **Screenshots** — Capture the game window as JPEG (`mc_screenshot`)
 - **Slash Commands** — Execute in-game commands (`mc_run_command`)
 - **Runtime Method Tracing** — Inject loggers into methods to trace calls (`mc_logger`)
+- **Runtime Entity/Inventory Inspection** — Query entities, inspect equipment, render item icons, and toggle client-side glow
 
 ## Quick Start
 
@@ -61,7 +62,7 @@ The `serve` subcommand starts the MCP server over stdio. Your MCP client (Claude
 
 | Version Type | Example | Notes |
 |--------------|---------|-------|
-| Dev snapshots | `26.1-snapshot-10` | Already unobfuscated, no mappings needed |
+| Dev snapshots | `26.2-snapshot-4`, `26w14a` | Already unobfuscated, no mappings needed |
 | Release (>= 1.21.11) | `1.21.11` | Uses pre-unobfuscated JAR when available |
 | Old versions | `< 1.21.11` | Not supported |
 
@@ -258,7 +259,8 @@ Capture the game window as a JPEG file and return its path.
 ```json
 {
   "downscale": 2,
-  "quality": 0.75
+  "quality": 0.75,
+  "timeoutMs": 5000
 }
 ```
 
@@ -270,6 +272,8 @@ Execute a Minecraft slash command.
   "command": "/give @s minecraft:diamond 64"
 }
 ```
+
+If the DebugBridge `runCommand` endpoint fails on a newer snapshot because the client connection API changed, mcdev-mcp retries through `mc_execute` using a field-first connection lookup.
 
 ### `mc_logger`
 Manage runtime method loggers for tracing Minecraft method calls. Uses Java Agent instrumentation to capture method entry/exit, arguments, return values, and timing.
@@ -302,6 +306,88 @@ List active loggers:
 ```
 
 > **Note:** This modifies bytecode at runtime. Avoid targeting hot-path methods. Optional filters (`throttle`, `arg_contains`, `arg_instanceof`, `sample`) can reduce log volume.
+
+### `mc_search_runtime`
+Search the live DebugBridge runtime resolver for classes, methods, or fields. Use this when connected to a running client and you want runtime names from the active DebugBridge mapping resolver.
+
+```json
+{
+  "pattern": "Minecraft",
+  "scope": "class"
+}
+```
+
+`scope` is optional and can be `all`, `class`, `method`, or `field`.
+
+### `mc_get_item_texture`
+Render an item from the player's inventory by slot and return PNG data.
+
+```json
+{
+  "slot": 0
+}
+```
+
+The result contains `base64Png`, `dataUri`, `width`, `height`, and `spriteName`.
+
+### `mc_get_item_texture_by_id`
+Render an item by registry id and return PNG data.
+
+```json
+{
+  "itemId": "minecraft:diamond_sword"
+}
+```
+
+### `mc_get_entity_item_texture`
+Render an equipped item from an entity by runtime entity id and equipment slot.
+
+```json
+{
+  "entityId": 12,
+  "slot": "mainhand"
+}
+```
+
+Typical slots are `mainhand`, `offhand`, `head`, `chest`, `legs`, and `feet`.
+
+### `mc_nearby_entities`
+List nearby entities from the running client.
+
+```json
+{
+  "range": 64,
+  "limit": 100
+}
+```
+
+### `mc_entity_details`
+Get detailed data for a runtime entity id returned by `mc_nearby_entities` or `mc_looked_at_entity`.
+
+```json
+{
+  "entityId": 12
+}
+```
+
+### `mc_looked_at_entity`
+Return the runtime entity id currently under the player's crosshair, if any.
+
+```json
+{
+  "range": 64
+}
+```
+
+### `mc_set_entity_glow`
+Toggle client-side glow for a runtime entity id.
+
+```json
+{
+  "entityId": 12,
+  "glow": true
+}
+```
 
 ## Requirements
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display_name": "Minecraft Dev MCP",
   "version": "1.0.0",
   "description": "MCP server for Minecraft mod development - decompiled code access, symbol search, and runtime interaction via DebugBridge",
-  "long_description": "An MCP server for AI-assisted Minecraft mod development. Static tools provide access to decompiled Minecraft source code: browse classes and methods, search symbols, explore package hierarchies, find subclasses/implementors, and trace callers/callees across multiple Minecraft versions. Runtime tools interact with a running Minecraft instance through the DebugBridge mod: execute Lua inside the JVM, capture game state snapshots and screenshots, run slash commands, and inject runtime method loggers.",
+  "long_description": "An MCP server for AI-assisted Minecraft mod development. Static tools provide access to decompiled Minecraft source code: browse classes and methods, search symbols, explore package hierarchies, find subclasses/implementors, and trace callers/callees across multiple Minecraft versions. Runtime tools interact with a running Minecraft instance through the DebugBridge mod: execute Lua inside the JVM, capture game state snapshots and screenshots, run slash commands, inspect entities and item textures, toggle entity glow, and inject runtime method loggers.",
   "author": {
     "name": "weikengchen",
     "url": "https://github.com/weikengchen"
@@ -53,7 +53,15 @@
     { "name": "mc_snapshot", "description": "Get a structured snapshot of current game state" },
     { "name": "mc_screenshot", "description": "Capture the Minecraft client framebuffer as a JPEG file" },
     { "name": "mc_run_command", "description": "Execute a Minecraft slash command" },
-    { "name": "mc_logger", "description": "Inject, cancel, or list runtime method loggers" }
+    { "name": "mc_logger", "description": "Inject, cancel, or list runtime method loggers" },
+    { "name": "mc_search_runtime", "description": "Search the live DebugBridge runtime resolver for classes, methods, and fields" },
+    { "name": "mc_get_item_texture", "description": "Render a player inventory slot item as PNG data" },
+    { "name": "mc_get_item_texture_by_id", "description": "Render an item registry id as PNG data" },
+    { "name": "mc_get_entity_item_texture", "description": "Render an equipped entity item as PNG data" },
+    { "name": "mc_nearby_entities", "description": "List entities near the player in the running client" },
+    { "name": "mc_entity_details", "description": "Get detailed data for a runtime entity id" },
+    { "name": "mc_looked_at_entity", "description": "Get the entity id currently under the player's crosshair" },
+    { "name": "mc_set_entity_glow", "description": "Toggle client-side glow for a runtime entity id" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/src/decompiler/remapper.ts
+++ b/src/decompiler/remapper.ts
@@ -22,8 +22,9 @@ export function getTinyMappingsPath(version: string): string {
 }
 
 export function needsRemapping(version: string): boolean {
-  // Dev snapshots (26.x+) are already unobfuscated
+  // Dev snapshots/new-version snapshots (26.x+, 26wNNa+) are already unobfuscated
   if (/^[2-9][0-9]*\./.test(version)) return false;
+  if (/^[2-9][0-9]*w[0-9]{2}[a-z]$/.test(version)) return false;
   // Versions with known unobfuscated JARs
   if (hasUnobfuscatedJar(version)) return false;
   // Everything else needs remapping

--- a/src/tools/runtime/bridge-response.ts
+++ b/src/tools/runtime/bridge-response.ts
@@ -1,0 +1,23 @@
+import { BridgeResponse } from "./types.js";
+
+export type McpTextResponse = {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: true;
+};
+
+export function errorText(message: string): McpTextResponse {
+    return { content: [{ type: "text", text: message }], isError: true };
+}
+
+export function bridgeError(resp: BridgeResponse): McpTextResponse {
+    return errorText(`Error: ${resp.error ?? "Unknown DebugBridge error"}`);
+}
+
+export function exceptionText(error: unknown): McpTextResponse {
+    const msg = error instanceof Error ? error.message : String(error);
+    return errorText(msg);
+}
+
+export function jsonText(value: unknown): McpTextResponse {
+    return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}

--- a/src/tools/runtime/command.ts
+++ b/src/tools/runtime/command.ts
@@ -1,5 +1,27 @@
 import { bridgeSession } from "./session.js";
 
+function luaString(value: string): string {
+    return JSON.stringify(value)
+        .replace(/\u2028/g, "\\u2028")
+        .replace(/\u2029/g, "\\u2029");
+}
+
+function commandFallbackLua(command: string): string {
+    const quoted = luaString(command);
+    return [
+        "local mc = java.import('net.minecraft.client.Minecraft'):getInstance()",
+        "local player = mc.player",
+        "if player == nil then error('Player not available') end",
+        "local ok, connection = pcall(function() return player.connection end)",
+        "if (not ok) or connection == nil then",
+        "  ok, connection = pcall(function() return player:connection() end)",
+        "end",
+        "if (not ok) or connection == nil then error('Player connection not available') end",
+        `connection:sendCommand(${quoted})`,
+        `return 'Command sent: ' .. ${quoted}`,
+    ].join("\n");
+}
+
 export const mcRunCommandTool = {
     name: "mc_run_command",
     description: `Execute a Minecraft slash command (e.g., "/give @s minecraft:diamond 64").
@@ -20,7 +42,16 @@ The leading "/" is optional.`,
             const cmd = args.command.startsWith("/") ? args.command.substring(1) : args.command;
             const resp = await bridgeSession.send("runCommand", { command: cmd });
             if (!resp.success) {
-                return { content: [{ type: "text" as const, text: `Error: ${resp.error}` }], isError: true };
+                const fallback = await bridgeSession.send("execute", { code: commandFallbackLua(cmd) });
+                if (!fallback.success) {
+                    const first = resp.error ?? "unknown runCommand error";
+                    const second = fallback.error ?? "unknown execute fallback error";
+                    return {
+                        content: [{ type: "text" as const, text: `Error: ${first}; fallback failed: ${second}` }],
+                        isError: true,
+                    };
+                }
+                return { content: [{ type: "text" as const, text: JSON.stringify(fallback.result, null, 2) }] };
             }
             return { content: [{ type: "text" as const, text: JSON.stringify(resp.result, null, 2) }] };
         } catch (e: unknown) {

--- a/src/tools/runtime/entities.ts
+++ b/src/tools/runtime/entities.ts
@@ -1,0 +1,119 @@
+import { bridgeSession } from "./session.js";
+import { bridgeError, exceptionText, jsonText } from "./bridge-response.js";
+
+export const mcNearbyEntitiesTool = {
+    name: "mc_nearby_entities",
+    description: `List nearby entities from the running Minecraft client through DebugBridge.
+Returns entity ids, names, types, distance, position, and equipment summaries when available.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            range: {
+                type: "number",
+                description: "Search radius in blocks. Default: 64.",
+            },
+            limit: {
+                type: "number",
+                description: "Maximum number of entities to return. Default: 100.",
+            },
+        },
+        required: [],
+    },
+
+    handler: async (args: { range?: number; limit?: number }) => {
+        try {
+            const resp = await bridgeSession.send("nearbyEntities", {
+                range: args.range ?? 64,
+                limit: args.limit ?? 100,
+            });
+            if (!resp.success) return bridgeError(resp);
+            return jsonText(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};
+
+export const mcEntityDetailsTool = {
+    name: "mc_entity_details",
+    description: `Fetch detailed DebugBridge data for one runtime entity id.
+Use entity ids returned by mc_nearby_entities or mc_looked_at_entity.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            entityId: {
+                type: "number",
+                description: "Runtime entity id.",
+            },
+        },
+        required: ["entityId"],
+    },
+
+    handler: async (args: { entityId: number }) => {
+        try {
+            const resp = await bridgeSession.send("entityDetails", { entityId: args.entityId });
+            if (!resp.success) return bridgeError(resp);
+            return jsonText(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};
+
+export const mcLookedAtEntityTool = {
+    name: "mc_looked_at_entity",
+    description: `Return the runtime entity id currently under the player's crosshair, if any.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            range: {
+                type: "number",
+                description: "Maximum raycast/search range in blocks. Default: 64.",
+            },
+        },
+        required: [],
+    },
+
+    handler: async (args: { range?: number }) => {
+        try {
+            const resp = await bridgeSession.send("lookedAtEntity", { range: args.range ?? 64 });
+            if (!resp.success) return bridgeError(resp);
+            return jsonText(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};
+
+export const mcSetEntityGlowTool = {
+    name: "mc_set_entity_glow",
+    description: `Enable or disable the client-side glow outline for a runtime entity id.
+This is visual-only and local to the client running DebugBridge.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            entityId: {
+                type: "number",
+                description: "Runtime entity id.",
+            },
+            glow: {
+                type: "boolean",
+                description: "true to enable glow, false to disable it.",
+            },
+        },
+        required: ["entityId", "glow"],
+    },
+
+    handler: async (args: { entityId: number; glow: boolean }) => {
+        try {
+            const resp = await bridgeSession.send("setEntityGlow", {
+                entityId: args.entityId,
+                glow: args.glow,
+            });
+            if (!resp.success) return bridgeError(resp);
+            return jsonText(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};

--- a/src/tools/runtime/index.ts
+++ b/src/tools/runtime/index.ts
@@ -5,6 +5,18 @@ export { mcScreenshotTool } from './screenshot.js';
 export { mcRunCommandTool } from './command.js';
 export { mcLoggerTool } from './logger.js';
 export { mcScriptLogsTool } from './script-logs.js';
+export { mcSearchRuntimeTool } from './search.js';
+export {
+    mcGetItemTextureTool,
+    mcGetItemTextureByIdTool,
+    mcGetEntityItemTextureTool,
+} from './items.js';
+export {
+    mcNearbyEntitiesTool,
+    mcEntityDetailsTool,
+    mcLookedAtEntityTool,
+    mcSetEntityGlowTool,
+} from './entities.js';
 
 import { mcConnectTool } from './connect.js';
 import { mcExecuteTool } from './execute.js';
@@ -13,6 +25,18 @@ import { mcScreenshotTool } from './screenshot.js';
 import { mcRunCommandTool } from './command.js';
 import { mcLoggerTool } from './logger.js';
 import { mcScriptLogsTool } from './script-logs.js';
+import { mcSearchRuntimeTool } from './search.js';
+import {
+    mcGetItemTextureTool,
+    mcGetItemTextureByIdTool,
+    mcGetEntityItemTextureTool,
+} from './items.js';
+import {
+    mcNearbyEntitiesTool,
+    mcEntityDetailsTool,
+    mcLookedAtEntityTool,
+    mcSetEntityGlowTool,
+} from './entities.js';
 
 // Dev-only tools (enabled via MCDEV_SCRIPT_LOGS=1)
 const devToolsEnabled = process.env.MCDEV_SCRIPT_LOGS === '1';
@@ -24,6 +48,14 @@ export const runtimeTools = [
     mcScreenshotTool,
     mcRunCommandTool,
     mcLoggerTool,
+    mcSearchRuntimeTool,
+    mcGetItemTextureTool,
+    mcGetItemTextureByIdTool,
+    mcGetEntityItemTextureTool,
+    mcNearbyEntitiesTool,
+    mcEntityDetailsTool,
+    mcLookedAtEntityTool,
+    mcSetEntityGlowTool,
     // Dev-only tools
     ...(devToolsEnabled ? [mcScriptLogsTool] : []),
 ];

--- a/src/tools/runtime/items.ts
+++ b/src/tools/runtime/items.ts
@@ -1,0 +1,107 @@
+import { bridgeSession } from "./session.js";
+import { bridgeError, exceptionText, jsonText, McpTextResponse } from "./bridge-response.js";
+
+type TextureResult = {
+    base64Png: string;
+    width: number;
+    height: number;
+    spriteName: string;
+};
+
+function formatTexture(result: unknown): McpTextResponse {
+    const texture = result as TextureResult | undefined;
+    if (!texture || typeof texture.base64Png !== "string") {
+        return { content: [{ type: "text", text: "Texture endpoint returned no PNG data." }], isError: true };
+    }
+
+    return jsonText({
+        ...texture,
+        dataUri: `data:image/png;base64,${texture.base64Png}`,
+    });
+}
+
+export const mcGetItemTextureTool = {
+    name: "mc_get_item_texture",
+    description: `Render an inventory slot item through DebugBridge and return PNG data.
+Use this for visual inspection of the player's inventory. The returned
+base64Png field is raw PNG bytes; dataUri is ready to embed in HTML.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            slot: {
+                type: "number",
+                description: "Inventory slot index to render.",
+            },
+        },
+        required: ["slot"],
+    },
+
+    handler: async (args: { slot: number }) => {
+        try {
+            const resp = await bridgeSession.send("getItemTexture", { slot: args.slot });
+            if (!resp.success) return bridgeError(resp);
+            return formatTexture(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};
+
+export const mcGetItemTextureByIdTool = {
+    name: "mc_get_item_texture_by_id",
+    description: `Render an item by registry id through DebugBridge and return PNG data.
+Useful when an entity or inventory payload contains an item id but no slot.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            itemId: {
+                type: "string",
+                description: "Item registry id, e.g. minecraft:diamond_sword.",
+            },
+        },
+        required: ["itemId"],
+    },
+
+    handler: async (args: { itemId: string }) => {
+        try {
+            const resp = await bridgeSession.send("getItemTextureById", { itemId: args.itemId });
+            if (!resp.success) return bridgeError(resp);
+            return formatTexture(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};
+
+export const mcGetEntityItemTextureTool = {
+    name: "mc_get_entity_item_texture",
+    description: `Render an equipped item from an entity by runtime entity id and equipment slot.
+Typical slots are mainhand, offhand, head, chest, legs, and feet.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            entityId: {
+                type: "number",
+                description: "Runtime entity id from mc_nearby_entities or mc_looked_at_entity.",
+            },
+            slot: {
+                type: "string",
+                description: "Equipment slot name: mainhand, offhand, head, chest, legs, or feet.",
+            },
+        },
+        required: ["entityId", "slot"],
+    },
+
+    handler: async (args: { entityId: number; slot: string }) => {
+        try {
+            const resp = await bridgeSession.send("getEntityItemTexture", {
+                entityId: args.entityId,
+                slot: args.slot,
+            });
+            if (!resp.success) return bridgeError(resp);
+            return formatTexture(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};

--- a/src/tools/runtime/screenshot.ts
+++ b/src/tools/runtime/screenshot.ts
@@ -26,15 +26,20 @@ path to be readable here.`,
                 type: "number",
                 description: "JPEG quality in [0.05, 1.0]. Default: 0.75.",
             },
+            timeoutMs: {
+                type: "number",
+                description: "Capture timeout in milliseconds. DebugBridge enforces a minimum of 100ms. Default: 5000.",
+            },
         },
         required: [],
     },
 
-    handler: async (args: { downscale?: number; quality?: number }) => {
+    handler: async (args: { downscale?: number; quality?: number; timeoutMs?: number }) => {
         try {
             const payload: Record<string, unknown> = {};
             if (args.downscale !== undefined) payload.downscale = args.downscale;
             if (args.quality !== undefined) payload.quality = args.quality;
+            if (args.timeoutMs !== undefined) payload.timeoutMs = args.timeoutMs;
             const resp = await bridgeSession.send("screenshot", payload);
             if (!resp.success) {
                 return { content: [{ type: "text" as const, text: `Error: ${resp.error}` }], isError: true };

--- a/src/tools/runtime/search.ts
+++ b/src/tools/runtime/search.ts
@@ -1,0 +1,38 @@
+import { bridgeSession } from "./session.js";
+import { bridgeError, exceptionText, jsonText } from "./bridge-response.js";
+
+type RuntimeSearchScope = "all" | "class" | "method" | "field";
+
+export const mcSearchRuntimeTool = {
+    name: "mc_search_runtime",
+    description: `Search DebugBridge's live runtime mapping resolver for classes, methods, or fields.
+This is useful while connected to a running client, especially for passthrough
+unobfuscated snapshots where runtime Mojang names are available directly.`,
+    inputSchema: {
+        type: "object" as const,
+        properties: {
+            pattern: {
+                type: "string",
+                description: "Case-insensitive regular expression to search for.",
+            },
+            scope: {
+                type: "string",
+                enum: ["all", "class", "method", "field"],
+                description: "Symbol scope to search. Default: all.",
+            },
+        },
+        required: ["pattern"],
+    },
+
+    handler: async (args: { pattern: string; scope?: RuntimeSearchScope }) => {
+        try {
+            const payload: Record<string, unknown> = { pattern: args.pattern };
+            if (args.scope !== undefined) payload.scope = args.scope;
+            const resp = await bridgeSession.send("search", payload);
+            if (!resp.success) return bridgeError(resp);
+            return jsonText(resp.result);
+        } catch (e: unknown) {
+            return exceptionText(e);
+        }
+    },
+};

--- a/src/tools/runtime/types.ts
+++ b/src/tools/runtime/types.ts
@@ -1,6 +1,22 @@
 export interface BridgeRequest {
     id: string;
-    type: "execute" | "search" | "snapshot" | "screenshot" | "runCommand" | "status" | "injectLogger" | "cancelLogger" | "listLoggers";
+    type:
+        | "execute"
+        | "search"
+        | "snapshot"
+        | "screenshot"
+        | "runCommand"
+        | "status"
+        | "getItemTexture"
+        | "getEntityItemTexture"
+        | "getItemTextureById"
+        | "nearbyEntities"
+        | "entityDetails"
+        | "lookedAtEntity"
+        | "setEntityGlow"
+        | "injectLogger"
+        | "cancelLogger"
+        | "listLoggers";
     payload: Record<string, unknown>;
 }
 

--- a/tests/remapper-compat.test.ts
+++ b/tests/remapper-compat.test.ts
@@ -1,0 +1,11 @@
+import { needsRemapping } from '../src/decompiler/remapper.js';
+
+describe('newer Minecraft version remapping compatibility', () => {
+  test('treats dotted 26.x snapshots as unobfuscated', () => {
+    expect(needsRemapping('26.2-snapshot-4')).toBe(false);
+  });
+
+  test('treats weekly 26w snapshots as unobfuscated', () => {
+    expect(needsRemapping('26w14a')).toBe(false);
+  });
+});

--- a/tests/runtime-endpoints.test.ts
+++ b/tests/runtime-endpoints.test.ts
@@ -1,0 +1,182 @@
+import { jest } from '@jest/globals';
+
+const sendMock = jest.fn();
+
+jest.unstable_mockModule('../src/tools/runtime/session.js', () => ({
+  bridgeSession: {
+    send: sendMock,
+  },
+}));
+
+const {
+  mcGetItemTextureTool,
+  mcGetItemTextureByIdTool,
+  mcGetEntityItemTextureTool,
+} = await import('../src/tools/runtime/items.js');
+
+const {
+  mcNearbyEntitiesTool,
+  mcEntityDetailsTool,
+  mcLookedAtEntityTool,
+  mcSetEntityGlowTool,
+} = await import('../src/tools/runtime/entities.js');
+
+const { mcSearchRuntimeTool } = await import('../src/tools/runtime/search.js');
+const { mcScreenshotTool } = await import('../src/tools/runtime/screenshot.js');
+const { mcRunCommandTool } = await import('../src/tools/runtime/command.js');
+
+function ok(result: unknown) {
+  return { id: 'req_1', success: true, result };
+}
+
+describe('DebugBridge runtime endpoint tools', () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+  });
+
+  test('mc_get_item_texture calls getItemTexture with slot payload', async () => {
+    sendMock.mockResolvedValueOnce(ok({
+      base64Png: 'abc',
+      width: 32,
+      height: 32,
+      spriteName: 'minecraft:diamond',
+    }) as never);
+
+    const response = await mcGetItemTextureTool.handler({ slot: 4 });
+
+    expect(sendMock).toHaveBeenCalledWith('getItemTexture', { slot: 4 });
+    expect(response.isError).toBeUndefined();
+    expect(response.content[0].text).toContain('"spriteName": "minecraft:diamond"');
+  });
+
+  test('mc_get_item_texture_by_id calls getItemTextureById with item id payload', async () => {
+    sendMock.mockResolvedValueOnce(ok({
+      base64Png: 'abc',
+      width: 32,
+      height: 32,
+      spriteName: 'minecraft:apple',
+    }) as never);
+
+    await mcGetItemTextureByIdTool.handler({ itemId: 'minecraft:apple' });
+
+    expect(sendMock).toHaveBeenCalledWith('getItemTextureById', { itemId: 'minecraft:apple' });
+  });
+
+  test('mc_get_entity_item_texture calls getEntityItemTexture with entity and slot payload', async () => {
+    sendMock.mockResolvedValueOnce(ok({
+      base64Png: 'abc',
+      width: 32,
+      height: 32,
+      spriteName: 'minecraft:iron_sword',
+    }) as never);
+
+    await mcGetEntityItemTextureTool.handler({ entityId: 12, slot: 'mainhand' });
+
+    expect(sendMock).toHaveBeenCalledWith('getEntityItemTexture', {
+      entityId: 12,
+      slot: 'mainhand',
+    });
+  });
+
+  test('mc_nearby_entities calls nearbyEntities with defaults when args are empty', async () => {
+    sendMock.mockResolvedValueOnce(ok({ entities: [], count: 0 }) as never);
+
+    await mcNearbyEntitiesTool.handler({});
+
+    expect(sendMock).toHaveBeenCalledWith('nearbyEntities', {
+      range: 64,
+      limit: 100,
+    });
+  });
+
+  test('mc_entity_details calls entityDetails with entity id payload', async () => {
+    sendMock.mockResolvedValueOnce(ok({ entityId: 12, type: 'net.minecraft.world.entity.Entity' }) as never);
+
+    await mcEntityDetailsTool.handler({ entityId: 12 });
+
+    expect(sendMock).toHaveBeenCalledWith('entityDetails', { entityId: 12 });
+  });
+
+  test('mc_looked_at_entity calls lookedAtEntity with range payload', async () => {
+    sendMock.mockResolvedValueOnce(ok({ entityId: 12 }) as never);
+
+    await mcLookedAtEntityTool.handler({ range: 48 });
+
+    expect(sendMock).toHaveBeenCalledWith('lookedAtEntity', { range: 48 });
+  });
+
+  test('mc_set_entity_glow calls setEntityGlow with entity id and glow payload', async () => {
+    sendMock.mockResolvedValueOnce(ok({ entityId: 12, glow: true }) as never);
+
+    await mcSetEntityGlowTool.handler({ entityId: 12, glow: true });
+
+    expect(sendMock).toHaveBeenCalledWith('setEntityGlow', {
+      entityId: 12,
+      glow: true,
+    });
+  });
+
+  test('mc_search_runtime calls search with pattern and scope payload', async () => {
+    sendMock.mockResolvedValueOnce(ok([{ type: 'class', name: 'net.minecraft.client.Minecraft' }]) as never);
+
+    await mcSearchRuntimeTool.handler({ pattern: 'Minecraft', scope: 'class' });
+
+    expect(sendMock).toHaveBeenCalledWith('search', {
+      pattern: 'Minecraft',
+      scope: 'class',
+    });
+  });
+
+  test('mc_screenshot forwards timeoutMs when provided', async () => {
+    sendMock.mockResolvedValueOnce(ok({
+      path: 'C:/tmp/debugbridge-screenshot.jpg',
+      width: 800,
+      height: 600,
+      sizeBytes: 1024,
+      mimeType: 'image/jpeg',
+    }) as never);
+
+    await mcScreenshotTool.handler({ downscale: 1, quality: 0.9, timeoutMs: 7500 });
+
+    expect(sendMock).toHaveBeenCalledWith('screenshot', {
+      downscale: 1,
+      quality: 0.9,
+      timeoutMs: 7500,
+    });
+  });
+
+  test('runtime tools return DebugBridge errors as MCP errors', async () => {
+    sendMock.mockResolvedValueOnce({
+      id: 'req_1',
+      success: false,
+      error: 'No texture provider configured',
+    } as never);
+
+    const response = await mcGetItemTextureTool.handler({ slot: 0 });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('No texture provider configured');
+  });
+
+  test('mc_run_command falls back to Lua execute for newer snapshots with connection field', async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        id: 'req_1',
+        success: false,
+        error: 'LuaError: No method connection',
+      } as never)
+      .mockResolvedValueOnce(ok('Command sent: say hi') as never);
+
+    const response = await mcRunCommandTool.handler({ command: '/say hi' });
+
+    expect(sendMock).toHaveBeenNthCalledWith(1, 'runCommand', { command: 'say hi' });
+    expect(sendMock).toHaveBeenNthCalledWith(2, 'execute', {
+      code: expect.stringContaining('player.connection'),
+    });
+    expect(sendMock).toHaveBeenNthCalledWith(2, 'execute', {
+      code: expect.stringContaining('connection:sendCommand("say hi")'),
+    });
+    expect(response.isError).toBeUndefined();
+    expect(response.content[0].text).toContain('Command sent');
+  });
+});


### PR DESCRIPTION
## Summary

Expands mcdev-mcp's DebugBridge runtime tool surface to cover every runtime endpoint currently exposed by DebugBridge:

- Adds runtime resolver search via `mc_search_runtime`.
- Adds item texture tools for inventory slots, registry ids, and entity equipment.
- Adds nearby entity, entity details, looked-at entity, and client-side glow tools.
- Adds `timeoutMs` passthrough for `mc_screenshot`.
- Keeps `mc_run_command` compatible with newer snapshots by falling back to `mc_execute` with a field-first player connection lookup if the DebugBridge `runCommand` endpoint fails.
- Treats weekly `26wNNx` snapshots as unobfuscated/no-remap, matching newer Minecraft snapshot behavior.