### PR TITLE
Update MCPB manifest for the Lua → Groovy migration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display_name": "Minecraft Dev MCP",
   "version": "2.0.0",
   "description": "MCP server for Minecraft mod development - decompiled code access, symbol search, and runtime interaction via DebugBridge",
-  "long_description": "An MCP server for AI-assisted Minecraft mod development. Static tools provide access to decompiled Minecraft source code: browse classes and methods, search symbols, explore package hierarchies, find subclasses/implementors, and trace callers/callees across multiple Minecraft versions. Runtime tools interact with a running Minecraft instance through the DebugBridge mod: execute Lua inside the JVM, capture game state snapshots and screenshots, inspect open GUI screens, list and inspect nearby entities and block-entities, render item textures from inventory slots or registry IDs, highlight entities or blocks in-world for the user, review recent chat, and run slash commands. Also exposes an MCP resources surface — including a Python client guide for the DebugBridge wire protocol — for agents that want to script the bridge directly instead of going through these tools.",
+  "long_description": "An MCP server for AI-assisted Minecraft mod development. Static tools provide access to decompiled Minecraft source code: browse classes and methods, search symbols, explore package hierarchies, find subclasses/implementors, and trace callers/callees across multiple Minecraft versions. Runtime tools interact with a running Minecraft instance through the DebugBridge mod: execute Groovy inside the JVM, capture game state snapshots and screenshots, inspect open GUI screens, list and inspect nearby entities and block-entities, render item textures from inventory slots or registry IDs, highlight entities or blocks in-world for the user, review recent chat, run slash commands, and drive session control (join/leave servers, quit the client, reconnect after a relaunch). Also exposes an MCP resources surface — including a Python client guide for the DebugBridge wire protocol and a build → deploy → relaunch → rejoin dev-loop guide — for agents that want to script the bridge directly instead of going through these tools.",
   "author": {
     "name": "weikengchen",
     "url": "https://github.com/weikengchen"
@@ -60,7 +60,7 @@
     { "name": "mc_find_hierarchy", "description": "Find subclasses or interface implementors of a class" },
     { "name": "mc_find_refs", "description": "Find callers or callees of a method via the callgraph" },
     { "name": "mc_connect", "description": "Connect to a running Minecraft instance via the DebugBridge mod" },
-    { "name": "mc_execute", "description": "Execute Lua code inside the running Minecraft JVM" },
+    { "name": "mc_execute", "description": "Execute Groovy code inside the running Minecraft JVM" },
     { "name": "mc_snapshot", "description": "Get a structured snapshot of current game state" },
     { "name": "mc_screenshot", "description": "Capture the Minecraft client framebuffer as a JPEG file" },
     { "name": "mc_screen_inspect", "description": "Snapshot the current GUI screen (chest, inventory, etc.) and its structure" },


### PR DESCRIPTION
Follow-up to the Lua → Groovy migration (9c5f54b) and #21: the MCPB manifest was the one surface both missed.

- `long_description` still said "execute Lua inside the JVM" → now Groovy, and it now also mentions the session-control tools and the dev-loop resource from #21.
- The `mc_execute` tool entry still said "Execute Lua code inside the running Minecraft JVM" → now Groovy.

These strings are what Claude Desktop shows in the extension listing, so they were actively misadvertising the scripting language. JSON validated; no code changes.

https://claude.ai/code/session_01LUmooEwCaCMvvesY2gXGV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUmooEwCaCMvvesY2gXGV1)_