### PR TITLE
Release v2.1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "mcdev-mcp",
   "display_name": "Minecraft Dev MCP",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server for Minecraft mod development - decompiled code access, symbol search, and runtime interaction via DebugBridge",
   "long_description": "An MCP server for AI-assisted Minecraft mod development. Static tools provide access to decompiled Minecraft source code: browse classes and methods, search symbols, explore package hierarchies, find subclasses/implementors, and trace callers/callees across multiple Minecraft versions. Runtime tools interact with a running Minecraft instance through the DebugBridge mod: execute Groovy inside the JVM, capture game state snapshots and screenshots, inspect open GUI screens, list and inspect nearby entities and block-entities, render item textures from inventory slots or registry IDs, highlight entities or blocks in-world for the user, review recent chat, run slash commands, and drive session control (join/leave servers, quit the client, reconnect after a relaunch). Also exposes an MCP resources surface — including a Python client guide for the DebugBridge wire protocol and a build → deploy → relaunch → rejoin dev-loop guide — for agents that want to script the bridge directly instead of going through these tools.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcdev-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcdev-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcdev-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server for Minecraft mod development - provides decompiled code access, symbol search, and runtime interaction via DebugBridge",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump to 2.1.0 in `package.json`, `package-lock.json`, and `manifest.json` (all three must match the tag per the `verify-version` CI job).

Once merged, the `v2.1.0` tag on the squash commit triggers the tag-driven pipeline: npm publish via trusted publishing + GitHub Release with the universal `.mcpb` bundle attached.

Release contents since 2.0.0: session-control tools (`mc_join_server`, `mc_leave_server`, `mc_quit_client`, `mc_wait_for_bridge`, `mc_wait_until_in_world`), the agent-driven dev-loop guide/skill (#21), the Lua → Groovy documentation cleanup (9c5f54b, #22), and the record-video and execute-timeout fixes.

https://claude.ai/code/session_01LUmooEwCaCMvvesY2gXGV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUmooEwCaCMvvesY2gXGV1)_