### PR TITLE
Replace PR #24 with bounded AST parsing and Tree-sitter backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "glob": "^13.0.6",
         "java-parser": "^3.0.1",
         "sql.js": "^1.14.1",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-java": "^0.23.5",
         "unzipper": "^0.12.3",
         "ws": "^8.20.1"
       },
@@ -5946,6 +5948,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -5954,6 +5965,17 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -7043,6 +7065,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-java": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
+    "compare:parsers": "npm run build && node scripts/compare-parser-backends.mjs",
     "prepublishOnly": "npm run build",
     "mcpb": "bash scripts/build-mcpb.sh"
   },
@@ -52,6 +53,8 @@
     "glob": "^13.0.6",
     "java-parser": "^3.0.1",
     "sql.js": "^1.14.1",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-java": "^0.23.5",
     "unzipper": "^0.12.3",
     "ws": "^8.20.1"
   },

--- a/scripts/compare-parser-backends.mjs
+++ b/scripts/compare-parser-backends.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { performance } from 'perf_hooks';
+import { glob } from 'glob';
+import { parseJavaContentAst } from '../dist/indexer/parser-ast.js';
+import { parseJavaContentTreeSitter } from '../dist/indexer/parser-tree-sitter.js';
+
+const sourceDir = process.argv[2];
+const limitArg = process.argv[3];
+const limit = limitArg ? Number.parseInt(limitArg, 10) : Infinity;
+const failOnMismatch = process.argv.includes('--fail-on-mismatch');
+
+if (!sourceDir) {
+  console.error('Usage: npm run compare:parsers -- <java-source-dir> [max-files] [--fail-on-mismatch]');
+  process.exit(2);
+}
+
+const absoluteSourceDir = path.resolve(sourceDir);
+const files = (await glob('**/*.java', {
+  cwd: absoluteSourceDir,
+  absolute: true,
+  nodir: true,
+})).sort((a, b) => a.localeCompare(b)).slice(0, Number.isFinite(limit) ? limit : undefined);
+
+function summarize(parsed) {
+  if (!parsed) return null;
+  return {
+    packageName: parsed.packageName,
+    className: parsed.className,
+    kind: parsed.info.kind,
+    super: parsed.info.super,
+    interfaces: parsed.info.interfaces,
+    fields: parsed.info.fields.map(field => field.name).sort(),
+    methods: parsed.info.methods.map(method => method.name).sort(),
+  };
+}
+
+async function runBackend(name, parse) {
+  const before = process.memoryUsage().rss;
+  const started = performance.now();
+  const summaries = new Map();
+  let parsed = 0;
+  let failed = 0;
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf-8');
+    const result = parse(source, file);
+    const summary = summarize(result);
+    if (summary) {
+      parsed++;
+      summaries.set(file, summary);
+    } else {
+      failed++;
+    }
+  }
+
+  const elapsedMs = performance.now() - started;
+  const after = process.memoryUsage().rss;
+  return {
+    name,
+    parsed,
+    failed,
+    elapsedMs: Math.round(elapsedMs),
+    rssDeltaMb: Math.round((after - before) / 1024 / 1024),
+    summaries,
+  };
+}
+
+const ast = await runBackend('java-parser', parseJavaContentAst);
+global.gc?.();
+const treeSitter = await runBackend('tree-sitter', parseJavaContentTreeSitter);
+
+const mismatches = [];
+for (const file of files) {
+  const a = ast.summaries.get(file);
+  const b = treeSitter.summaries.get(file);
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    mismatches.push({
+      file: path.relative(absoluteSourceDir, file),
+      javaParser: a,
+      treeSitter: b,
+    });
+  }
+}
+
+const output = {
+  sourceDir: absoluteSourceDir,
+  files: files.length,
+  backends: [
+    {
+      name: ast.name,
+      parsed: ast.parsed,
+      failed: ast.failed,
+      elapsedMs: ast.elapsedMs,
+      rssDeltaMb: ast.rssDeltaMb,
+    },
+    {
+      name: treeSitter.name,
+      parsed: treeSitter.parsed,
+      failed: treeSitter.failed,
+      elapsedMs: treeSitter.elapsedMs,
+      rssDeltaMb: treeSitter.rssDeltaMb,
+    },
+  ],
+  mismatches: mismatches.slice(0, 25),
+  mismatchCount: mismatches.length,
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(failOnMismatch && mismatches.length > 0 ? 1 : 0);

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,14 +1,22 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
+import { fork } from 'child_process';
+import { fileURLToPath } from 'url';
 import { glob } from 'glob';
 import { PackageIndex, IndexManifest, ClassInfo } from '../utils/types.js';
-import { parseJavaFile, ParsedClass, getParserBackend } from './parser.js';
+import { parseJavaFile, getParserBackend, type ParsedClass, type ParserBackend } from './parser.js';
 import {
   getVersionedIndexManifestPath,
   getVersionedPackageIndexPath,
   ensureVersionedIndexDirs
 } from '../utils/paths.js';
 import { readJsonFileOrNull } from '../utils/json-file.js';
+
+const AST_WORKER_BATCH_SIZE = 10;
+const AST_WORKER_HEAP_MB = 2048;
+const AST_WORKER_RETRY_HEAP_MB = 8192;
+const WORKER_STDERR_LIMIT = 8000;
 
 export interface BuildIndexOptions {
   minecraftSourceDir: string;
@@ -26,89 +34,397 @@ export interface IndexBuildResult {
 
 export async function buildIndex(options: BuildIndexOptions): Promise<IndexBuildResult> {
   const { minecraftSourceDir, fabricApiSourceDir, minecraftVersion, fabricApiVersion, progressCb } = options;
-  
+
   ensureVersionedIndexDirs(minecraftVersion);
-  
+
   if (progressCb) progressCb('index', 0, 'Finding Java files...');
-  
+
   const mcJavaFiles = await findJavaFiles(minecraftSourceDir);
   const fabricJavaFiles = fabricApiSourceDir ? await findJavaFiles(fabricApiSourceDir) : [];
-  
+
   const totalFiles = mcJavaFiles.length + fabricJavaFiles.length;
-  let processedFiles = 0;
-  
-  const minecraftPackages = new Map<string, Record<string, ClassInfo>>();
-  const fabricPackages = new Map<string, Record<string, ClassInfo>>();
-  
+  const parserBackend = getParserBackend();
+  let totalClasses = 0;
+
+  const minecraftPackages = new Set<string>();
+  const fabricPackages = new Set<string>();
+  const writtenMinecraftPackages = new Set<string>();
+  const writtenFabricPackages = new Set<string>();
+
   if (progressCb) progressCb('index', 5, `Processing ${mcJavaFiles.length} Minecraft files...`);
-  
-  for (const file of mcJavaFiles) {
-    const parsed = parseJavaFile(file);
-    if (parsed) {
-      addToPackageIndex(minecraftPackages, parsed);
-    }
-    processedFiles++;
-    if (progressCb && processedFiles % 500 === 0) {
-      const progress = Math.round(5 + (processedFiles / totalFiles) * 85);
-      progressCb('index', progress, `Processed ${processedFiles}/${totalFiles} files...`);
-    }
-  }
-  
-  if (fabricJavaFiles.length > 0) {
-    if (progressCb) progressCb('index', 50, `Processing ${fabricJavaFiles.length} Fabric API files...`);
+
+  const processedAfterMinecraft = await processJavaFiles({
+    files: mcJavaFiles,
+    namespace: 'minecraft',
+    version: minecraftVersion,
+    parserBackend,
+    packageNames: minecraftPackages,
+    writtenPackageNames: writtenMinecraftPackages,
+    totalFiles,
+    processedOffset: 0,
+    onClassIndexed: () => { totalClasses++; },
+    progressCb,
+  });
+
+  if (fabricJavaFiles.length > 0 && progressCb) {
+    progressCb('index', 50, `Processing ${fabricJavaFiles.length} Fabric API files...`);
   }
 
-  for (const file of fabricJavaFiles) {
-    const parsed = parseJavaFile(file);
-    if (parsed) {
-      addToPackageIndex(fabricPackages, parsed);
-    }
-    processedFiles++;
-    if (progressCb && processedFiles % 500 === 0) {
-      const progress = Math.round(5 + (processedFiles / totalFiles) * 85);
-      progressCb('index', progress, `Processed ${processedFiles}/${totalFiles} files...`);
-    }
-  }
-  
-  if (progressCb) progressCb('index', 90, 'Writing package indices...');
-  
-  await writePackageIndices('minecraft', minecraftPackages, minecraftVersion);
-  await writePackageIndices('fabric', fabricPackages, minecraftVersion);
-  
+  await processJavaFiles({
+    files: fabricJavaFiles,
+    namespace: 'fabric',
+    version: minecraftVersion,
+    parserBackend,
+    packageNames: fabricPackages,
+    writtenPackageNames: writtenFabricPackages,
+    totalFiles,
+    processedOffset: processedAfterMinecraft,
+    onClassIndexed: () => { totalClasses++; },
+    progressCb,
+  });
+
+  if (progressCb) progressCb('index', 90, 'Writing index manifest...');
+
   const manifest: IndexManifest = {
     minecraftVersion,
     fabricApiVersion: fabricApiVersion || null,
     generated: new Date().toISOString(),
-    indexerVersion: getParserBackend(),
+    indexerVersion: parserBackend,
     packages: {
-      minecraft: Array.from(minecraftPackages.keys()).sort(),
-      fabric: Array.from(fabricPackages.keys()).sort(),
+      minecraft: Array.from(minecraftPackages).sort(),
+      fabric: Array.from(fabricPackages).sort(),
     },
   };
-  
+
   const manifestPath = getVersionedIndexManifestPath(minecraftVersion);
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-  
-  let totalClasses = 0;
-  for (const pkg of minecraftPackages.values()) {
-    totalClasses += Object.keys(pkg).length;
+
+  if (progressCb) {
+    progressCb('index', 100, `Indexed ${totalClasses} classes in ${minecraftPackages.size + fabricPackages.size} packages.`);
   }
-  for (const pkg of fabricPackages.values()) {
-    totalClasses += Object.keys(pkg).length;
-  }
-  
-  if (progressCb) progressCb('index', 100, `Indexed ${totalClasses} classes in ${minecraftPackages.size + fabricPackages.size} packages.`);
-  
+
   return {
-    minecraftPackages: Array.from(minecraftPackages.keys()),
-    fabricPackages: Array.from(fabricPackages.keys()),
+    minecraftPackages: Array.from(minecraftPackages).sort(),
+    fabricPackages: Array.from(fabricPackages).sort(),
     totalClasses,
   };
 }
 
+interface ProcessJavaFilesOptions {
+  files: string[];
+  namespace: 'minecraft' | 'fabric';
+  version: string;
+  parserBackend: ParserBackend;
+  packageNames: Set<string>;
+  writtenPackageNames: Set<string>;
+  totalFiles: number;
+  processedOffset: number;
+  onClassIndexed: () => void;
+  progressCb?: (stage: string, progress: number, message: string) => void;
+}
+
+async function processJavaFiles(options: ProcessJavaFilesOptions): Promise<number> {
+  const {
+    files,
+    namespace,
+    version,
+    parserBackend,
+    packageNames,
+    writtenPackageNames,
+    totalFiles,
+    processedOffset,
+    onClassIndexed,
+    progressCb,
+  } = options;
+
+  const sortedFiles = [...files].sort((a, b) => a.localeCompare(b));
+  let processedFiles = processedOffset;
+  let nextProgressAt = Math.floor(processedOffset / 500) * 500 + 500;
+  let activePackage: string | null = null;
+  let activeClasses: Record<string, ClassInfo> | null = null;
+
+  async function flushActivePackage(): Promise<void> {
+    if (activePackage && activeClasses && Object.keys(activeClasses).length > 0) {
+      await flushPackage(namespace, activePackage, activeClasses, version, packageNames, writtenPackageNames);
+    }
+    activePackage = null;
+    activeClasses = null;
+  }
+
+  async function indexParsedClass(parsed: ParsedClass): Promise<void> {
+    const packageName = parsed.packageName || 'default';
+
+    if (activePackage !== null && packageName !== activePackage) {
+      await flushActivePackage();
+      await yieldForGc();
+    }
+
+    if (activePackage !== packageName) {
+      activePackage = packageName;
+      activeClasses = {};
+    }
+
+    activeClasses![parsed.className] = {
+      ...parsed.info,
+      sourcePath: parsed.info.sourcePath,
+    };
+    onClassIndexed();
+  }
+
+  function reportProcessed(count: number): void {
+    processedFiles += count;
+    if (progressCb && totalFiles > 0 && processedFiles >= nextProgressAt) {
+      const progress = Math.round(5 + (processedFiles / totalFiles) * 85);
+      progressCb('index', progress, `Processed ${processedFiles}/${totalFiles} files...`);
+      while (processedFiles >= nextProgressAt) nextProgressAt += 500;
+    }
+  }
+
+  if (shouldUseAstWorkers(sortedFiles.length, parserBackend)) {
+    await parseJavaFilesInWorkerBatches(sortedFiles, async batch => {
+      for (const parsed of batch.parsed) {
+        await indexParsedClass(parsed);
+      }
+    }, reportProcessed);
+  } else {
+    for (const file of sortedFiles) {
+      const parsed = parseJavaFile(file);
+      if (parsed) {
+        await indexParsedClass(parsed);
+      }
+
+      reportProcessed(1);
+      if (processedFiles % 100 === 0) {
+        await yieldForGc();
+      }
+    }
+  }
+
+  await flushActivePackage();
+  return processedFiles;
+}
+
+interface ParsedBatch {
+  fileCount: number;
+  parsed: ParsedClass[];
+}
+
+function shouldUseAstWorkers(fileCount: number, parserBackend: ParserBackend): boolean {
+  if (fileCount === 0 || parserBackend !== 'ast') return false;
+  if (getAstWorkerCount() < 1) return false;
+  return fs.existsSync(getParseWorkerPath());
+}
+
+async function parseJavaFilesInWorkerBatches(
+  sortedFiles: string[],
+  onBatchParsed: (batch: ParsedBatch) => Promise<void>,
+  onScheduledBatchComplete?: (fileCount: number) => void,
+): Promise<void> {
+  const batchSize = getAstWorkerBatchSize();
+  const batches: string[][] = [];
+  for (let i = 0; i < sortedFiles.length; i += batchSize) {
+    batches.push(sortedFiles.slice(i, i + batchSize));
+  }
+
+  const completedBatches = new Map<number, ParsedBatch>();
+  const workerCount = Math.min(getAstWorkerCount(), batches.length);
+  let nextBatch = 0;
+  let nextBatchToIndex = 0;
+  let consumeTail = Promise.resolve();
+
+  function consumeReadyBatches(): Promise<void> {
+    consumeTail = consumeTail.then(async () => {
+      while (completedBatches.has(nextBatchToIndex)) {
+        const batch = completedBatches.get(nextBatchToIndex)!;
+        completedBatches.delete(nextBatchToIndex);
+        await onBatchParsed(batch);
+        nextBatchToIndex++;
+        await yieldForGc();
+      }
+    });
+    return consumeTail;
+  }
+
+  async function runNextBatch(): Promise<void> {
+    while (nextBatch < batches.length) {
+      const batchIndex = nextBatch++;
+      const files = batches[batchIndex];
+      const parsed = await parseBatchWithRetry(files);
+      completedBatches.set(batchIndex, { fileCount: files.length, parsed });
+      if (onScheduledBatchComplete) onScheduledBatchComplete(files.length);
+      await consumeReadyBatches();
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => runNextBatch()));
+  await consumeReadyBatches();
+}
+
+async function parseBatchWithRetry(files: string[]): Promise<ParsedClass[]> {
+  try {
+    return await parseBatchInWorker(files);
+  } catch (error) {
+    if (files.length <= 1) {
+      const retryHeapMb = getAstWorkerRetryHeapMb();
+      if (retryHeapMb > getAstWorkerHeapMb()) {
+        try {
+          return await parseBatchInWorker(files, retryHeapMb);
+        } catch {}
+      }
+
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(`Java parse worker failed for ${files[0]}: ${cause}`, { cause: error });
+    }
+
+    const midpoint = Math.floor(files.length / 2);
+    const left = await parseBatchWithRetry(files.slice(0, midpoint));
+    const right = await parseBatchWithRetry(files.slice(midpoint));
+    return [...left, ...right];
+  }
+}
+
+function parseBatchInWorker(files: string[], heapMb = getAstWorkerHeapMb()): Promise<ParsedClass[]> {
+  const workerPath = getParseWorkerPath();
+  markWorkerUsed(files.length);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stderr = '';
+    const child = fork(workerPath, [], {
+      env: {
+        ...process.env,
+        MCDEV_AST_PARSER: '1',
+        MCDEV_TREE_SITTER_PARSER: '',
+      },
+      execArgv: [
+        ...getWorkerExecArgv(),
+        `--max-old-space-size=${heapMb}`,
+      ],
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.length > WORKER_STDERR_LIMIT) {
+        stderr = stderr.slice(-WORKER_STDERR_LIMIT);
+      }
+    });
+
+    child.on('message', (message: unknown) => {
+      const msg = message as { type?: string; parsed?: ParsedClass[]; error?: string };
+      if (msg.type === 'result' && Array.isArray(msg.parsed)) {
+        settled = true;
+        resolve(msg.parsed);
+        return;
+      }
+      if (msg.type === 'error') {
+        settled = true;
+        reject(new Error(msg.error || 'Java parse worker failed.'));
+      }
+    });
+
+    child.on('error', error => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+
+    child.on('exit', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      const detail = stderr.trim() ? `\n${stderr.trim()}` : '';
+      reject(new Error(`Java parse worker exited with ${signal ?? `code ${code}`}.${detail}`));
+    });
+
+    child.send({ type: 'parse', files });
+  });
+}
+
+function markWorkerUsed(fileCount: number): void {
+  const markerPath = process.env.MCDEV_INDEX_WORKER_MARKER;
+  if (!markerPath) return;
+  fs.appendFileSync(markerPath, `${fileCount}\n`);
+}
+
+function getParseWorkerPath(): string {
+  const override = process.env.MCDEV_INDEX_PARSE_WORKER_PATH;
+  if (override) return override;
+  return fileURLToPath(new URL('./parse-worker.js', import.meta.url));
+}
+
+function getWorkerExecArgv(): string[] {
+  const args: string[] = [];
+  for (let i = 0; i < process.execArgv.length; i++) {
+    const arg = process.execArgv[i];
+    if (
+      arg.startsWith('--max-old-space-size=') ||
+      arg.startsWith('--input-type=') ||
+      arg === '--input-type' ||
+      arg === '--eval' ||
+      arg === '-e' ||
+      arg === '--print' ||
+      arg === '-p'
+    ) {
+      if (arg === '--input-type' || arg === '--eval' || arg === '-e' || arg === '--print' || arg === '-p') i++;
+      continue;
+    }
+    args.push(arg);
+  }
+  return args;
+}
+
+function getAstWorkerCount(): number {
+  const cpuCount = typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length;
+  const defaultWorkers = Math.max(1, Math.min(2, cpuCount - 1));
+  return readIntEnv('MCDEV_INDEX_WORKERS', defaultWorkers, 0, 32);
+}
+
+function getAstWorkerBatchSize(): number {
+  return readIntEnv('MCDEV_INDEX_BATCH_SIZE', AST_WORKER_BATCH_SIZE, 1, 2000);
+}
+
+function getAstWorkerHeapMb(): number {
+  return readIntEnv('MCDEV_INDEX_WORKER_HEAP_MB', AST_WORKER_HEAP_MB, 128, 32768);
+}
+
+function getAstWorkerRetryHeapMb(): number {
+  return readIntEnv('MCDEV_INDEX_WORKER_RETRY_HEAP_MB', AST_WORKER_RETRY_HEAP_MB, 128, 32768);
+}
+
+function readIntEnv(name: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+async function flushPackage(
+  namespace: 'minecraft' | 'fabric',
+  packageName: string,
+  classes: Record<string, ClassInfo>,
+  version: string,
+  packageNames: Set<string>,
+  writtenPackageNames: Set<string>,
+): Promise<void> {
+  const indexPath = getVersionedPackageIndexPath(namespace, packageName, version);
+  const existing = writtenPackageNames.has(packageName)
+    ? readJsonFileOrNull<PackageIndex>(indexPath, `indexer/package-merge:${version}/${namespace}/${packageName}`)
+    : null;
+  const mergedClasses = existing ? { ...existing.classes, ...classes } : classes;
+
+  await writePackageIndex(namespace, packageName, mergedClasses, version);
+  packageNames.add(packageName);
+  writtenPackageNames.add(packageName);
+}
+
+function yieldForGc(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
 async function findJavaFiles(dir: string): Promise<string[]> {
   if (!fs.existsSync(dir)) return [];
-  
+
   return glob('**/*.java', {
     cwd: dir,
     absolute: true,
@@ -116,43 +432,23 @@ async function findJavaFiles(dir: string): Promise<string[]> {
   });
 }
 
-function addToPackageIndex(
-  packages: Map<string, Record<string, ClassInfo>>,
-  parsed: ParsedClass
-): void {
-  const packageName = parsed.packageName || 'default';
-  
-  if (!packages.has(packageName)) {
-    packages.set(packageName, {});
-  }
-  
-  const pkgIndex = packages.get(packageName)!;
-  const relativeClassName = parsed.className;
-  
-  pkgIndex[relativeClassName] = {
-    ...parsed.info,
-    sourcePath: parsed.info.sourcePath,
-  };
-}
-
-async function writePackageIndices(
+async function writePackageIndex(
   namespace: 'minecraft' | 'fabric',
-  packages: Map<string, Record<string, ClassInfo>>,
-  version: string
+  packageName: string,
+  classes: Record<string, ClassInfo>,
+  version: string,
 ): Promise<void> {
-  for (const [packageName, classes] of packages) {
-    const packageIndex: PackageIndex = {
-      package: packageName,
-      classes,
-    };
-    
-    const indexPath = getVersionedPackageIndexPath(namespace, packageName, version);
-    const dir = path.dirname(indexPath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-    fs.writeFileSync(indexPath, JSON.stringify(packageIndex, null, 2));
+  const packageIndex: PackageIndex = {
+    package: packageName,
+    classes,
+  };
+
+  const indexPath = getVersionedPackageIndexPath(namespace, packageName, version);
+  const dir = path.dirname(indexPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
   }
+  fs.writeFileSync(indexPath, JSON.stringify(packageIndex, null, 2));
 }
 
 export function loadIndexManifest(version?: string): IndexManifest | null {

--- a/src/indexer/parse-worker.ts
+++ b/src/indexer/parse-worker.ts
@@ -1,0 +1,47 @@
+import { parseJavaFile, type ParsedClass } from './parser.js';
+
+interface ParseRequest {
+  type: 'parse';
+  files: string[];
+}
+
+interface ParseResult {
+  type: 'result';
+  parsed: ParsedClass[];
+}
+
+interface ParseFailure {
+  type: 'error';
+  error: string;
+}
+
+function sendAndExit(message: ParseResult | ParseFailure, exitCode: number): void {
+  if (process.send) {
+    process.send(message, () => {
+      process.exit(exitCode);
+    });
+    return;
+  }
+  process.exit(exitCode);
+}
+
+process.on('message', (message: ParseRequest) => {
+  if (!message || message.type !== 'parse' || !Array.isArray(message.files)) {
+    sendAndExit({ type: 'error', error: 'Invalid parse worker request.' }, 1);
+    return;
+  }
+
+  try {
+    const parsed: ParsedClass[] = [];
+    for (const file of message.files) {
+      const result = parseJavaFile(file);
+      if (result) parsed.push(result);
+    }
+    sendAndExit({ type: 'result', parsed }, 0);
+  } catch (error) {
+    sendAndExit({
+      type: 'error',
+      error: error instanceof Error ? error.stack ?? error.message : String(error),
+    }, 1);
+  }
+});

--- a/src/indexer/parser-ast.ts
+++ b/src/indexer/parser-ast.ts
@@ -35,9 +35,14 @@ export function parseJavaFileAst(filePath: string): ParsedClass | null {
 }
 
 export function parseJavaContentAst(content: string, filePath: string): ParsedClass | null {
-    let cst: CstNode;
+    let pkgName: string;
+    let top: TopLevelType | null;
     try {
-        cst = parse(content) as CstNode;
+        const cst = parse(content) as CstNode;
+        const visitor = new JavaIndexVisitor();
+        visitor.visit(cst);
+        pkgName = visitor.pkgName;
+        top = visitor.topLevel;
     } catch {
         // Match the regex parser's contract: on unparseable input, return
         // null rather than throwing. buildIndex() then skips this file
@@ -45,17 +50,14 @@ export function parseJavaContentAst(content: string, filePath: string): ParsedCl
         return null;
     }
 
-    const visitor = new JavaIndexVisitor();
-    visitor.visit(cst);
-    const top = visitor.topLevel;
     if (!top || !top.className) return null;
 
     const relativePath = filePath.replace(/\\/g, '/');
 
     return {
-        packageName: visitor.pkgName,
+        packageName: pkgName,
         className: top.className,
-        fullName: visitor.pkgName ? `${visitor.pkgName}.${top.className}` : top.className,
+        fullName: pkgName ? `${pkgName}.${top.className}` : top.className,
         info: {
             kind: top.kind,
             super: top.superClass,
@@ -64,7 +66,6 @@ export function parseJavaContentAst(content: string, filePath: string): ParsedCl
             methods: top.methods,
             sourcePath: relativePath,
         },
-        rawContent: content,
     };
 }
 

--- a/src/indexer/parser-tree-sitter.ts
+++ b/src/indexer/parser-tree-sitter.ts
@@ -1,0 +1,259 @@
+/**
+ * Experimental Java index parser backed by Tree-sitter.
+ *
+ * The indexer only needs a shallow structural summary, so a concrete syntax
+ * tree is enough: package, top-level type, direct fields, direct methods, and
+ * declaration line ranges. Keep this backend behind MCDEV_TREE_SITTER_PARSER
+ * until corpus comparisons show it matches the java-parser backend closely.
+ */
+
+import * as fs from 'fs';
+import Parser from 'tree-sitter';
+import Java from 'tree-sitter-java';
+import { ClassKind, FieldInfo, MethodInfo } from '../utils/types.js';
+import type { ParsedClass } from './parser.js';
+
+type SyntaxNode = Parser.SyntaxNode;
+
+let sharedParser: Parser | null = null;
+
+export function parseJavaFileTreeSitter(filePath: string): ParsedClass | null {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  return parseJavaContentTreeSitter(content, filePath);
+}
+
+export function parseJavaContentTreeSitter(content: string, filePath: string): ParsedClass | null {
+  let tree: Parser.Tree;
+  try {
+    tree = getParser().parse(content);
+  } catch {
+    return null;
+  }
+  if (tree.rootNode.hasError) return null;
+
+  const packageName = readPackageName(tree.rootNode);
+  const top = findTopLevelType(tree.rootNode);
+  if (!top) return null;
+
+  const className = childText(top, 'name');
+  if (!className) return null;
+
+  const kind = kindForNode(top);
+  const relativePath = filePath.replace(/\\/g, '/');
+  const fields = readFields(top, kind);
+  const methods = readMethods(top);
+
+  return {
+    packageName,
+    className,
+    fullName: packageName ? `${packageName}.${className}` : className,
+    info: {
+      kind,
+      super: readSuperClass(top, kind),
+      interfaces: readInterfaces(top, kind),
+      fields,
+      methods,
+      sourcePath: relativePath,
+    },
+  };
+}
+
+function getParser(): Parser {
+  if (!sharedParser) {
+    sharedParser = new Parser();
+    sharedParser.setLanguage(Java);
+  }
+  return sharedParser;
+}
+
+function readPackageName(root: SyntaxNode): string {
+  const decl = root.namedChildren.find(child => child.type === 'package_declaration');
+  if (!decl) return '';
+  const nameNode = decl.namedChildren.find(child =>
+    child.type === 'scoped_identifier' ||
+    child.type === 'identifier'
+  );
+  return nameNode?.text ?? '';
+}
+
+function findTopLevelType(root: SyntaxNode): SyntaxNode | null {
+  return root.namedChildren.find(child =>
+    child.type === 'class_declaration' ||
+    child.type === 'interface_declaration' ||
+    child.type === 'enum_declaration' ||
+    child.type === 'record_declaration'
+  ) ?? null;
+}
+
+function kindForNode(node: SyntaxNode): ClassKind {
+  if (node.type === 'interface_declaration') return 'interface';
+  if (node.type === 'enum_declaration') return 'enum';
+  if (node.type === 'record_declaration') return 'record';
+  return 'class';
+}
+
+function childText(node: SyntaxNode, fieldName: string): string | null {
+  return node.childForFieldName(fieldName)?.text ?? null;
+}
+
+function readSuperClass(node: SyntaxNode, kind: ClassKind): string | null {
+  if (kind === 'interface') return null;
+  const superclass = node.childForFieldName('superclass');
+  const typeNode = superclass?.namedChildren.find(isTypeNode);
+  return typeNode ? simpleTypeName(typeNode.text) : null;
+}
+
+function readInterfaces(node: SyntaxNode, kind: ClassKind): string[] {
+  const container = kind === 'interface'
+    ? node.namedChildren.find(child => child.type === 'extends_interfaces')
+    : node.namedChildren.find(child => child.type === 'super_interfaces');
+  if (!container) return [];
+  const typeList = container.namedChildren.find(child => child.type === 'type_list') ?? container;
+  return typeList
+    .namedChildren
+    .filter(isTypeNode)
+    .map(child => simpleTypeName(child.text))
+    .filter(Boolean);
+}
+
+function readFields(typeNode: SyntaxNode, kind: ClassKind): FieldInfo[] {
+  const body = readBody(typeNode);
+  const fields: FieldInfo[] = [];
+
+  if (kind === 'record') {
+    const params = typeNode.namedChildren.find(child => child.type === 'formal_parameters');
+    if (params) {
+      for (const param of params.namedChildren.filter(child => child.type === 'formal_parameter')) {
+        const field = readParamAsField(param);
+        if (field) fields.push(field);
+      }
+    }
+  }
+
+  if (!body) return fields;
+  const declarations = memberContainers(body).flatMap(container =>
+    container.namedChildren.filter(child =>
+      child.type === 'field_declaration' ||
+      child.type === 'constant_declaration'
+    )
+  );
+
+  for (const declaration of declarations) {
+    const modifiers = readModifiers(declaration);
+    if (declaration.type === 'constant_declaration') {
+      for (const implicit of ['public', 'static', 'final']) {
+        if (!modifiers.includes(implicit)) modifiers.push(implicit);
+      }
+    }
+    const typeText = readDeclaredType(declaration);
+    for (const variable of declaration.namedChildren.filter(child => child.type === 'variable_declarator')) {
+      const name = childText(variable, 'name') ?? variable.namedChildren.find(child => child.type === 'identifier')?.text;
+      if (name) fields.push({ name, type: typeText, modifiers: [...modifiers] });
+    }
+  }
+
+  return fields;
+}
+
+function readParamAsField(param: SyntaxNode): FieldInfo | null {
+  const name = childText(param, 'name') ?? param.namedChildren.find(child => child.type === 'identifier')?.text;
+  const typeNode = param.childForFieldName('type') ?? param.namedChildren.find(isTypeNode);
+  if (!name || !typeNode) return null;
+  return {
+    name,
+    type: simpleTypeName(typeNode.text),
+    modifiers: ['final'],
+  };
+}
+
+function readMethods(typeNode: SyntaxNode): MethodInfo[] {
+  const body = readBody(typeNode);
+  if (!body) return [];
+
+  return memberContainers(body)
+    .flatMap(container => container.namedChildren.filter(child => child.type === 'method_declaration'))
+    .map(readMethod)
+    .filter((method): method is MethodInfo => method !== null);
+}
+
+function readMethod(node: SyntaxNode): MethodInfo | null {
+  const name = childText(node, 'name');
+  if (!name) return null;
+  const typeNode = node.childForFieldName('type') ?? node.namedChildren.find(isTypeNode);
+  const returnType = typeNode ? simpleTypeName(typeNode.text) : 'void';
+  const paramsNode = node.childForFieldName('parameters') ?? node.namedChildren.find(child => child.type === 'formal_parameters');
+
+  return {
+    name,
+    returnType,
+    params: paramsNode ? readParams(paramsNode) : [],
+    modifiers: readModifiers(node),
+    lineStart: node.startPosition.row + 1,
+    lineEnd: node.endPosition.row + 1,
+  };
+}
+
+function readParams(paramsNode: SyntaxNode): { name: string; type: string }[] {
+  return paramsNode.namedChildren
+    .filter(child => child.type === 'formal_parameter' || child.type === 'spread_parameter')
+    .map(param => {
+      const name = childText(param, 'name') ?? param.namedChildren.find(child => child.type === 'identifier')?.text;
+      const typeNode = param.childForFieldName('type') ?? param.namedChildren.find(isTypeNode);
+      if (!name || !typeNode) return null;
+      return { name, type: simpleTypeName(typeNode.text) };
+    })
+    .filter((param): param is { name: string; type: string } => param !== null);
+}
+
+function readBody(node: SyntaxNode): SyntaxNode | null {
+  return node.namedChildren.find(child =>
+    child.type === 'class_body' ||
+    child.type === 'interface_body' ||
+    child.type === 'enum_body'
+  ) ?? null;
+}
+
+function memberContainers(body: SyntaxNode): SyntaxNode[] {
+  return [
+    body,
+    ...body.namedChildren.filter(child => child.type === 'enum_body_declarations'),
+  ];
+}
+
+function readModifiers(node: SyntaxNode): string[] {
+  const modifiers = node.namedChildren.find(child => child.type === 'modifiers');
+  if (!modifiers) return [];
+  return modifiers.text
+    .split(/\s+/)
+    .map(text => text.trim())
+    .filter(text => text.length > 0 && !text.startsWith('@'));
+}
+
+function readDeclaredType(node: SyntaxNode): string {
+  const typeNode = node.childForFieldName('type') ?? node.namedChildren.find(isTypeNode);
+  return typeNode ? simpleTypeName(typeNode.text) : '';
+}
+
+function isTypeNode(node: SyntaxNode): boolean {
+  return isTypeNameNode(node) ||
+    node.type === 'integral_type' ||
+    node.type === 'floating_point_type' ||
+    node.type === 'boolean_type' ||
+    node.type === 'void_type' ||
+    node.type === 'array_type' ||
+    node.type === 'generic_type';
+}
+
+function isTypeNameNode(node: SyntaxNode): boolean {
+  return node.type === 'type_identifier' ||
+    node.type === 'scoped_type_identifier' ||
+    node.type === 'identifier';
+}
+
+function simpleTypeName(type: string): string {
+  const withoutGenerics = type.replace(/<.*>/s, '');
+  const withoutArrays = withoutGenerics.replace(/[[\]]/g, '');
+  const firstToken = withoutArrays.trim().split(/\s+/)[0] ?? '';
+  const segments = firstToken.split('.');
+  return segments[segments.length - 1] || firstToken;
+}

--- a/src/indexer/parser-tree-sitter.ts
+++ b/src/indexer/parser-tree-sitter.ts
@@ -8,13 +8,17 @@
  */
 
 import * as fs from 'fs';
-import Parser from 'tree-sitter';
-import Java from 'tree-sitter-java';
+import { createRequire } from 'module';
+import type Parser from 'tree-sitter';
 import { ClassKind, FieldInfo, MethodInfo } from '../utils/types.js';
 import type { ParsedClass } from './parser.js';
 
 type SyntaxNode = Parser.SyntaxNode;
+type ParserConstructor = new () => Parser;
 
+const require = createRequire(import.meta.url);
+let ParserCtor: ParserConstructor | null = null;
+let javaLanguage: unknown | null = null;
 let sharedParser: Parser | null = null;
 
 export function parseJavaFileTreeSitter(filePath: string): ParsedClass | null {
@@ -29,10 +33,11 @@ export function parseJavaContentTreeSitter(content: string, filePath: string): P
   } catch {
     return null;
   }
-  if (tree.rootNode.hasError) return null;
+  const rootNode = readRootNode(tree);
+  if (!rootNode || rootNode.hasError) return null;
 
-  const packageName = readPackageName(tree.rootNode);
-  const top = findTopLevelType(tree.rootNode);
+  const packageName = readPackageName(rootNode);
+  const top = findTopLevelType(rootNode);
   if (!top) return null;
 
   const className = childText(top, 'name');
@@ -60,10 +65,36 @@ export function parseJavaContentTreeSitter(content: string, filePath: string): P
 
 function getParser(): Parser {
   if (!sharedParser) {
+    const { Parser, Java } = loadTreeSitter();
     sharedParser = new Parser();
     sharedParser.setLanguage(Java);
   }
   return sharedParser;
+}
+
+function loadTreeSitter(): { Parser: ParserConstructor; Java: unknown } {
+  if (!ParserCtor || !javaLanguage) {
+    ParserCtor = require('tree-sitter') as ParserConstructor;
+    javaLanguage = require('tree-sitter-java') as unknown;
+  }
+  return { Parser: ParserCtor, Java: javaLanguage };
+}
+
+function readRootNode(tree: Parser.Tree | null | undefined): SyntaxNode | null {
+  if (!tree) return null;
+
+  try {
+    const rootNode = tree.rootNode;
+    if (rootNode) return rootNode;
+  } catch {
+    // Fall through to rootNodeWithOffset below.
+  }
+
+  try {
+    return tree.rootNodeWithOffset(0, { row: 0, column: 0 }) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function readPackageName(root: SyntaxNode): string {

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -2,13 +2,13 @@ import * as fs from 'fs';
 import { ClassInfo, FieldInfo, MethodInfo, ClassKind } from '../utils/types.js';
 import { isEnvOn } from '../utils/env.js';
 import { parseJavaFileAst, parseJavaContentAst } from './parser-ast.js';
+import { parseJavaFileTreeSitter, parseJavaContentTreeSitter } from './parser-tree-sitter.js';
 
 export interface ParsedClass {
   packageName: string;
   className: string;
   fullName: string;
   info: ClassInfo;
-  rawContent: string;
 }
 
 /**
@@ -18,18 +18,22 @@ export interface ParsedClass {
  * — see .dream/review.md). The AST parser (`'ast'`) is `java-parser`-backed
  * (Chevrotain CST) and handles all of those.
  *
- * Toggle with `MCDEV_AST_PARSER=1` (or `true`). One release of mutual
- * coexistence is intentional: it lets users compare index quality against
- * the regex baseline before we flip the default.
+ * Toggle with `MCDEV_AST_PARSER=1` (or `true`). `MCDEV_TREE_SITTER_PARSER=1`
+ * selects the experimental Tree-sitter backend instead. One release of mutual
+ * coexistence is intentional: it lets users compare index quality against the
+ * regex baseline before we flip the default.
  */
-export type ParserBackend = 'regex' | 'ast';
+export type ParserBackend = 'regex' | 'ast' | 'tree-sitter';
 
 export function getParserBackend(): ParserBackend {
+  if (isEnvOn('MCDEV_TREE_SITTER_PARSER')) return 'tree-sitter';
   return isEnvOn('MCDEV_AST_PARSER') ? 'ast' : 'regex';
 }
 
 export function parseJavaFile(filePath: string): ParsedClass | null {
-  if (getParserBackend() === 'ast') return parseJavaFileAst(filePath);
+  const backend = getParserBackend();
+  if (backend === 'ast') return parseJavaFileAst(filePath);
+  if (backend === 'tree-sitter') return parseJavaFileTreeSitter(filePath);
   const content = fs.readFileSync(filePath, 'utf-8');
   return parseJavaContentRegex(content, filePath);
 }
@@ -79,7 +83,9 @@ function parseDeclaration(block: string): {
 }
 
 export function parseJavaContent(content: string, filePath: string): ParsedClass | null {
-  if (getParserBackend() === 'ast') return parseJavaContentAst(content, filePath);
+  const backend = getParserBackend();
+  if (backend === 'ast') return parseJavaContentAst(content, filePath);
+  if (backend === 'tree-sitter') return parseJavaContentTreeSitter(content, filePath);
   return parseJavaContentRegex(content, filePath);
 }
 
@@ -114,7 +120,6 @@ function parseJavaContentRegex(content: string, filePath: string): ParsedClass |
       methods,
       sourcePath: relativePath,
     },
-    rawContent: content,
   };
 }
 

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -3,7 +3,6 @@ export interface ParsedClass {
   className: string;
   fullName: string;
   info: import('../utils/types.js').ClassInfo;
-  rawContent: string;
 }
 
 export interface IndexBuildResult {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -46,7 +46,7 @@ export interface IndexManifest {
    * so an upgrade to the AST parser can detect stale-but-still-usable
    * indices and prompt for a `rebuild`.
    */
-  indexerVersion?: 'regex' | 'ast';
+  indexerVersion?: 'regex' | 'ast' | 'tree-sitter';
   packages: {
     minecraft: string[];
     fabric: string[];

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { buildIndex, loadPackageIndex } from '../src/indexer/index.js';
+import { getVersionedIndexManifestPath } from '../src/utils/paths.js';
+import { readJsonFileOrNull } from '../src/utils/json-file.js';
+import type { IndexManifest } from '../src/utils/types.js';
 
 describe('Index Builder', () => {
   const tempDir = path.join(os.tmpdir(), 'mcdev-mcp-test-' + Date.now());
@@ -53,6 +56,113 @@ public class TestClass extends BaseClass implements TestInterface {
     expect(result.minecraftPackages).toContain('net.minecraft.test');
     expect(result.totalClasses).toBeGreaterThan(0);
   });
+
+  test('merges package index flushes when package files are non-contiguous', async () => {
+    const version = `split-package-${Date.now()}`;
+    const files = [
+      ['aaa', 'One.java', 'net.shared', 'One'],
+      ['bbb', 'Middle.java', 'net.other', 'Middle'],
+      ['ccc', 'Two.java', 'net.shared', 'Two'],
+    ];
+
+    for (const [dir, fileName, pkg, className] of files) {
+      const targetDir = path.join(tempDir, dir);
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, fileName), `
+package ${pkg};
+
+public class ${className} {
+    public void run() {}
+}
+`);
+    }
+
+    await buildIndex({
+      minecraftSourceDir: tempDir,
+      fabricApiSourceDir: null,
+      minecraftVersion: version,
+      fabricApiVersion: null,
+    });
+
+    const sharedPackage = loadPackageIndex('minecraft', 'net.shared', version);
+    expect(Object.keys(sharedPackage?.classes ?? {}).sort()).toEqual(['One', 'Two']);
+  });
+});
+
+describe('AST parser worker index build', () => {
+  const ORIG_AST = process.env.MCDEV_AST_PARSER;
+  const ORIG_TREE = process.env.MCDEV_TREE_SITTER_PARSER;
+  const ORIG_WORKERS = process.env.MCDEV_INDEX_WORKERS;
+  const ORIG_BATCH = process.env.MCDEV_INDEX_BATCH_SIZE;
+  const ORIG_WORKER_PATH = process.env.MCDEV_INDEX_PARSE_WORKER_PATH;
+  const ORIG_MARKER = process.env.MCDEV_INDEX_WORKER_MARKER;
+  const tempDir = path.join(os.tmpdir(), 'mcdev-mcp-ast-worker-' + Date.now());
+
+  beforeEach(() => {
+    process.env.MCDEV_AST_PARSER = '1';
+    delete process.env.MCDEV_TREE_SITTER_PARSER;
+    process.env.MCDEV_INDEX_WORKERS = '1';
+    process.env.MCDEV_INDEX_BATCH_SIZE = '1';
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (ORIG_AST === undefined) delete process.env.MCDEV_AST_PARSER;
+    else process.env.MCDEV_AST_PARSER = ORIG_AST;
+    if (ORIG_TREE === undefined) delete process.env.MCDEV_TREE_SITTER_PARSER;
+    else process.env.MCDEV_TREE_SITTER_PARSER = ORIG_TREE;
+    if (ORIG_WORKERS === undefined) delete process.env.MCDEV_INDEX_WORKERS;
+    else process.env.MCDEV_INDEX_WORKERS = ORIG_WORKERS;
+    if (ORIG_BATCH === undefined) delete process.env.MCDEV_INDEX_BATCH_SIZE;
+    else process.env.MCDEV_INDEX_BATCH_SIZE = ORIG_BATCH;
+    if (ORIG_WORKER_PATH === undefined) delete process.env.MCDEV_INDEX_PARSE_WORKER_PATH;
+    else process.env.MCDEV_INDEX_PARSE_WORKER_PATH = ORIG_WORKER_PATH;
+    if (ORIG_MARKER === undefined) delete process.env.MCDEV_INDEX_WORKER_MARKER;
+    else process.env.MCDEV_INDEX_WORKER_MARKER = ORIG_MARKER;
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('builds through the compiled parse worker and records an ast manifest', async () => {
+    const workerPath = path.join(process.cwd(), 'dist', 'indexer', 'parse-worker.js');
+    expect(fs.existsSync(workerPath)).toBe(true);
+    process.env.MCDEV_INDEX_PARSE_WORKER_PATH = workerPath;
+
+    const markerPath = path.join(tempDir, 'worker-used.txt');
+    process.env.MCDEV_INDEX_WORKER_MARKER = markerPath;
+
+    const pkgDir = path.join(tempDir, 'worker');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    for (let i = 0; i < 3; i++) {
+      fs.writeFileSync(path.join(pkgDir, `Worker${i}.java`), `
+package worker.test;
+
+public class Worker${i} {
+    public int value${i}() { return ${i}; }
+}
+`);
+    }
+
+    const version = `ast-worker-${Date.now()}`;
+    const result = await buildIndex({
+      minecraftSourceDir: tempDir,
+      fabricApiSourceDir: null,
+      minecraftVersion: version,
+      fabricApiVersion: null,
+    });
+
+    expect(result.totalClasses).toBe(3);
+    expect(fs.readFileSync(markerPath, 'utf-8').trim().split('\n')).toHaveLength(3);
+
+    const manifest = readJsonFileOrNull<IndexManifest>(
+      getVersionedIndexManifestPath(version),
+      'test/worker-manifest'
+    );
+    expect(manifest?.indexerVersion).toBe('ast');
+  }, 20000);
 });
 
 describe('Package Index Loader', () => {

--- a/tests/parser-ast.test.ts
+++ b/tests/parser-ast.test.ts
@@ -263,3 +263,21 @@ public class C extends Base implements Foo, Bar {}
         expect(a.info.interfaces).toEqual(r.info.interfaces);
     });
 });
+
+describe('AST parser — memory shape', () => {
+    it('does not retain rawContent on parse results', () => {
+        const src = `
+package net.minecraft.test;
+
+public class MemoryShape {
+    private int value;
+    public void run() {}
+}
+`;
+        const r = parseJavaContentAst(src, '/MemoryShape.java');
+        expect(r).not.toBeNull();
+        expect(r?.info.fields.length).toBeGreaterThan(0);
+        expect(r?.info.methods.length).toBeGreaterThan(0);
+        expect(Object.prototype.hasOwnProperty.call(r, 'rawContent')).toBe(false);
+    });
+});

--- a/tests/parser-tree-sitter.test.ts
+++ b/tests/parser-tree-sitter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from '@jest/globals';
+import { parseJavaContent } from '../src/indexer/parser.js';
+import { parseJavaContentAst } from '../src/indexer/parser-ast.js';
+import { parseJavaContentTreeSitter } from '../src/indexer/parser-tree-sitter.js';
+
+describe('Tree-sitter parser backend', () => {
+  it('extracts the same top-level class summary as the java-parser AST backend', () => {
+    const src = `
+package net.minecraft.network.chat;
+
+@Deprecated
+public final class Tricky<T extends Comparable<? super T>>
+        extends AbstractMap<String, java.util.List<? extends T>>
+        implements Cloneable, Serializable {
+    private static final int LIMIT = 256;
+    public int demo(String name) { return LIMIT; }
+}
+`;
+
+    const tree = parseJavaContentTreeSitter(src, '/x/Tricky.java');
+    const ast = parseJavaContentAst(src, '/x/Tricky.java');
+
+    expect(tree).not.toBeNull();
+    expect(ast).not.toBeNull();
+    expect(tree?.packageName).toBe(ast?.packageName);
+    expect(tree?.className).toBe(ast?.className);
+    expect(tree?.info.kind).toBe(ast?.info.kind);
+    expect(tree?.info.super).toBe(ast?.info.super);
+    expect(tree?.info.interfaces).toEqual(ast?.info.interfaces);
+    expect(tree?.info.fields.map(field => field.name)).toEqual(['LIMIT']);
+    expect(tree?.info.methods.map(method => method.name)).toEqual(['demo']);
+  });
+
+  it('extracts record components and interface members', () => {
+    const record = parseJavaContentTreeSitter(`
+package x;
+public record Pair(int left, String right) {}
+`, '/x/Pair.java');
+    expect(record?.info.kind).toBe('record');
+    expect(record?.info.fields.map(field => field.name)).toEqual(['left', 'right']);
+
+    const iface = parseJavaContentTreeSitter(`
+package x;
+public interface Named extends Base, Marker {
+    int LIMIT = 1;
+    default String name() { return "named"; }
+}
+`, '/x/Named.java');
+    expect(iface?.info.kind).toBe('interface');
+    expect(iface?.info.interfaces).toEqual(['Base', 'Marker']);
+    expect(iface?.info.fields.map(field => field.name)).toEqual(['LIMIT']);
+    expect(iface?.info.methods.map(method => method.name)).toEqual(['name']);
+  });
+
+  it('can be selected through MCDEV_TREE_SITTER_PARSER', () => {
+    const oldTree = process.env.MCDEV_TREE_SITTER_PARSER;
+    const oldAst = process.env.MCDEV_AST_PARSER;
+    process.env.MCDEV_TREE_SITTER_PARSER = '1';
+    process.env.MCDEV_AST_PARSER = '1';
+    try {
+      const result = parseJavaContent(`
+package selected;
+public class Backend { public void run() {} }
+`, '/Backend.java');
+      expect(result?.packageName).toBe('selected');
+      expect(result?.className).toBe('Backend');
+    } finally {
+      if (oldTree === undefined) delete process.env.MCDEV_TREE_SITTER_PARSER;
+      else process.env.MCDEV_TREE_SITTER_PARSER = oldTree;
+      if (oldAst === undefined) delete process.env.MCDEV_AST_PARSER;
+      else process.env.MCDEV_AST_PARSER = oldAst;
+    }
+  });
+
+  it('returns null on parse errors', () => {
+    expect(parseJavaContentTreeSitter('this is { not valid Java }', '/Bad.java')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces/supersedes #24 with a bounded-memory AST indexing path and an experimental non-`java-parser` backend.

- removes `rawContent` retention from parsed class results and narrows the Java CST lifetime to the extraction scope
- moves `MCDEV_AST_PARSER=1` indexing into short-lived child workers with bounded batch sizes and retry heap controls
- streams package index writes safely, including repeated/non-contiguous packages without overwriting earlier classes
- adds an opt-in Tree-sitter Java backend behind `MCDEV_TREE_SITTER_PARSER=1`
- adds parser comparison tooling with `npm run compare:parsers -- <java-source-dir> [max-files] [--fail-on-mismatch]`

## Why

PR #24 fixed the immediate OOM risk by streaming package writes, but the parent process could still retain large parser objects and the package flush strategy could overwrite classes when the same package appeared in multiple non-contiguous chunks. This version keeps the dependable Java parser path while bounding parser lifetime more aggressively: each AST batch is parsed in a short-lived worker, then only compact class summaries cross back to the parent.

The original thread also suggested looking at a non-Java AST. This PR includes Tree-sitter as an opt-in backend because early measurement looks promising, but it is not made the default yet because there is still small structural drift versus the current Java parser extraction behavior.

## Local comparison

Command:

```bash
npm run compare:parsers -- "/Users/cusgadmin/Library/Caches/mcdev-mcp/cache/1.21.11/client" 100
```

Results from the 100-file sample:

- `java-parser`: parsed 87, failed 13, elapsed about 777ms, RSS delta about +64MB
- `tree-sitter`: parsed 86, failed 14, elapsed about 114ms, RSS delta about +11MB
- mismatch count: 3

Remaining drift observed in the sample:

- one file parsed by `java-parser` but rejected by Tree-sitter due parser error handling
- two files where `java-parser` currently includes nested record/type member names in the top-level method list, while Tree-sitter omits nested-type members

That suggests Tree-sitter may become the better default later, but this PR keeps it opt-in until larger-source comparison is clean enough.

## Tests

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run compare:parsers -- "/Users/cusgadmin/Library/Caches/mcdev-mcp/cache/1.21.11/client" 100`

Notes:

- lint exits successfully with the existing unrelated `no-explicit-any` warnings
- local install still reports the existing Node 20 vs `commander@15` engine warning, but build/typecheck/test passed
