### PR TITLE
[codex] Fix AST worker fallback for pathological files

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Set `MCDEV_AST_PARSER=1` before `init` or `rebuild` to use the new [java-parser]
 - Picks up interface constants and `default`/`static` interface methods that the regex parser misses.
 - Does not fold nested-class members into the outer type's lists.
 
-In a head-to-head on Minecraft 1.21.11 source (500-file sample), the AST parser found **~2× more fields** and **~33% fewer (correctly attributed) methods** than the regex parser. It is ~4.5× slower per file, so a full re-index runs in roughly **75 seconds** instead of 17 — acceptable inside an `init` that already takes 2–5 minutes for download + decompile. Very large generated command classes are isolated in bounded worker processes; if `java-parser` still exhausts a worker on one file, the indexer falls back to the Tree-sitter parser for that file instead of failing the whole rebuild.
+In a head-to-head on Minecraft 1.21.11 source (500-file sample), the AST parser found **~2× more fields** and **~33% fewer (correctly attributed) methods** than the regex parser. It is ~4.5× slower per file, so a full re-index runs in roughly **75 seconds** instead of 17 — acceptable inside an `init` that already takes 2–5 minutes for download + decompile. Very large generated command classes are isolated in bounded worker processes; if `java-parser` still exhausts a worker on one file, the indexer falls back to Tree-sitter and then the regex parser for that file instead of failing the whole rebuild.
 
 ```bash
 MCDEV_AST_PARSER=1 npx mcdev-mcp init -v 1.21.11

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Set `MCDEV_AST_PARSER=1` before `init` or `rebuild` to use the new [java-parser]
 - Picks up interface constants and `default`/`static` interface methods that the regex parser misses.
 - Does not fold nested-class members into the outer type's lists.
 
-In a head-to-head on Minecraft 1.21.11 source (500-file sample), the AST parser found **~2× more fields** and **~33% fewer (correctly attributed) methods** than the regex parser. It is ~4.5× slower per file, so a full re-index runs in roughly **75 seconds** instead of 17 — acceptable inside an `init` that already takes 2–5 minutes for download + decompile.
+In a head-to-head on Minecraft 1.21.11 source (500-file sample), the AST parser found **~2× more fields** and **~33% fewer (correctly attributed) methods** than the regex parser. It is ~4.5× slower per file, so a full re-index runs in roughly **75 seconds** instead of 17 — acceptable inside an `init` that already takes 2–5 minutes for download + decompile. Very large generated command classes are isolated in bounded worker processes; if `java-parser` still exhausts a worker on one file, the indexer falls back to the Tree-sitter parser for that file instead of failing the whole rebuild.
 
 ```bash
 MCDEV_AST_PARSER=1 npx mcdev-mcp init -v 1.21.11

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5,7 +5,13 @@ import { fork } from 'child_process';
 import { fileURLToPath } from 'url';
 import { glob } from 'glob';
 import { PackageIndex, IndexManifest, ClassInfo } from '../utils/types.js';
-import { parseJavaFile, getParserBackend, type ParsedClass, type ParserBackend } from './parser.js';
+import {
+  parseJavaFile,
+  parseJavaFileWithBackend,
+  getParserBackend,
+  type ParsedClass,
+  type ParserBackend
+} from './parser.js';
 import {
   getVersionedIndexManifestPath,
   getVersionedPackageIndexPath,
@@ -265,11 +271,17 @@ async function parseBatchWithRetry(files: string[]): Promise<ParsedClass[]> {
     return await parseBatchInWorker(files);
   } catch (error) {
     if (files.length <= 1) {
+      const fallback = parseSingleFileWithTreeSitter(files[0]);
+      if (fallback !== null) return fallback;
+
       const retryHeapMb = getAstWorkerRetryHeapMb();
       if (retryHeapMb > getAstWorkerHeapMb()) {
         try {
           return await parseBatchInWorker(files, retryHeapMb);
-        } catch {}
+        } catch (retryError) {
+          const cause = retryError instanceof Error ? retryError.message : String(retryError);
+          throw new Error(`Java parse worker failed for ${files[0]}: ${cause}`, { cause: retryError });
+        }
       }
 
       const cause = error instanceof Error ? error.message : String(error);
@@ -280,6 +292,15 @@ async function parseBatchWithRetry(files: string[]): Promise<ParsedClass[]> {
     const left = await parseBatchWithRetry(files.slice(0, midpoint));
     const right = await parseBatchWithRetry(files.slice(midpoint));
     return [...left, ...right];
+  }
+}
+
+function parseSingleFileWithTreeSitter(file: string): ParsedClass[] | null {
+  try {
+    const parsed = parseJavaFileWithBackend(file, 'tree-sitter');
+    return parsed ? [parsed] : [];
+  } catch {
+    return null;
   }
 }
 
@@ -356,21 +377,36 @@ function getWorkerExecArgv(): string[] {
   const args: string[] = [];
   for (let i = 0; i < process.execArgv.length; i++) {
     const arg = process.execArgv[i];
-    if (
-      arg.startsWith('--max-old-space-size=') ||
-      arg.startsWith('--input-type=') ||
-      arg === '--input-type' ||
-      arg === '--eval' ||
-      arg === '-e' ||
-      arg === '--print' ||
-      arg === '-p'
-    ) {
-      if (arg === '--input-type' || arg === '--eval' || arg === '-e' || arg === '--print' || arg === '-p') i++;
+    if (isInlineWorkerArgOverride(arg)) {
+      continue;
+    }
+    if (isWorkerArgWithValue(arg)) {
+      i++;
       continue;
     }
     args.push(arg);
   }
   return args;
+}
+
+function isInlineWorkerArgOverride(arg: string): boolean {
+  return arg.startsWith('--max-old-space-size=') ||
+    arg.startsWith('--max_old_space_size=') ||
+    arg.startsWith('--max-old-space-size-percentage=') ||
+    arg.startsWith('--max_old_space_size_percentage=') ||
+    arg.startsWith('--input-type=');
+}
+
+function isWorkerArgWithValue(arg: string): boolean {
+  return arg === '--max-old-space-size' ||
+    arg === '--max_old_space_size' ||
+    arg === '--max-old-space-size-percentage' ||
+    arg === '--max_old_space_size_percentage' ||
+    arg === '--input-type' ||
+    arg === '--eval' ||
+    arg === '-e' ||
+    arg === '--print' ||
+    arg === '-p';
 }
 
 function getAstWorkerCount(): number {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -271,7 +271,7 @@ async function parseBatchWithRetry(files: string[]): Promise<ParsedClass[]> {
     return await parseBatchInWorker(files);
   } catch (error) {
     if (files.length <= 1) {
-      const fallback = parseSingleFileWithTreeSitter(files[0]);
+      const fallback = parseSingleFileAfterWorkerFailure(files[0]);
       if (fallback !== null) return fallback;
 
       const retryHeapMb = getAstWorkerRetryHeapMb();
@@ -295,13 +295,20 @@ async function parseBatchWithRetry(files: string[]): Promise<ParsedClass[]> {
   }
 }
 
-function parseSingleFileWithTreeSitter(file: string): ParsedClass[] | null {
-  try {
-    const parsed = parseJavaFileWithBackend(file, 'tree-sitter');
-    return parsed ? [parsed] : [];
-  } catch {
-    return null;
+function parseSingleFileAfterWorkerFailure(file: string): ParsedClass[] | null {
+  for (const backend of getSingleFileFallbackBackends()) {
+    try {
+      const parsed = parseJavaFileWithBackend(file, backend);
+      return parsed ? [parsed] : [];
+    } catch {}
   }
+  return null;
+}
+
+function getSingleFileFallbackBackends(): ParserBackend[] {
+  const override = process.env.MCDEV_INDEX_SINGLE_FILE_FALLBACK;
+  if (override === 'regex' || override === 'tree-sitter') return [override];
+  return ['tree-sitter', 'regex'];
 }
 
 function parseBatchInWorker(files: string[], heapMb = getAstWorkerHeapMb()): Promise<ParsedClass[]> {

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -31,7 +31,10 @@ export function getParserBackend(): ParserBackend {
 }
 
 export function parseJavaFile(filePath: string): ParsedClass | null {
-  const backend = getParserBackend();
+  return parseJavaFileWithBackend(filePath, getParserBackend());
+}
+
+export function parseJavaFileWithBackend(filePath: string, backend: ParserBackend): ParsedClass | null {
   if (backend === 'ast') return parseJavaFileAst(filePath);
   if (backend === 'tree-sitter') return parseJavaFileTreeSitter(filePath);
   const content = fs.readFileSync(filePath, 'utf-8');
@@ -83,7 +86,14 @@ function parseDeclaration(block: string): {
 }
 
 export function parseJavaContent(content: string, filePath: string): ParsedClass | null {
-  const backend = getParserBackend();
+  return parseJavaContentWithBackend(content, filePath, getParserBackend());
+}
+
+export function parseJavaContentWithBackend(
+  content: string,
+  filePath: string,
+  backend: ParserBackend
+): ParsedClass | null {
   if (backend === 'ast') return parseJavaContentAst(content, filePath);
   if (backend === 'tree-sitter') return parseJavaContentTreeSitter(content, filePath);
   return parseJavaContentRegex(content, filePath);

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -94,8 +94,12 @@ describe('AST parser worker index build', () => {
   const ORIG_TREE = process.env.MCDEV_TREE_SITTER_PARSER;
   const ORIG_WORKERS = process.env.MCDEV_INDEX_WORKERS;
   const ORIG_BATCH = process.env.MCDEV_INDEX_BATCH_SIZE;
+  const ORIG_HEAP = process.env.MCDEV_INDEX_WORKER_HEAP_MB;
+  const ORIG_RETRY_HEAP = process.env.MCDEV_INDEX_WORKER_RETRY_HEAP_MB;
   const ORIG_WORKER_PATH = process.env.MCDEV_INDEX_PARSE_WORKER_PATH;
   const ORIG_MARKER = process.env.MCDEV_INDEX_WORKER_MARKER;
+  const ORIG_ARGV_CAPTURE = process.env.MCDEV_ARGV_CAPTURE;
+  const ORIG_EXEC_ARGV = [...process.execArgv];
   const tempDir = path.join(os.tmpdir(), 'mcdev-mcp-ast-worker-' + Date.now());
 
   beforeEach(() => {
@@ -117,10 +121,17 @@ describe('AST parser worker index build', () => {
     else process.env.MCDEV_INDEX_WORKERS = ORIG_WORKERS;
     if (ORIG_BATCH === undefined) delete process.env.MCDEV_INDEX_BATCH_SIZE;
     else process.env.MCDEV_INDEX_BATCH_SIZE = ORIG_BATCH;
+    if (ORIG_HEAP === undefined) delete process.env.MCDEV_INDEX_WORKER_HEAP_MB;
+    else process.env.MCDEV_INDEX_WORKER_HEAP_MB = ORIG_HEAP;
+    if (ORIG_RETRY_HEAP === undefined) delete process.env.MCDEV_INDEX_WORKER_RETRY_HEAP_MB;
+    else process.env.MCDEV_INDEX_WORKER_RETRY_HEAP_MB = ORIG_RETRY_HEAP;
     if (ORIG_WORKER_PATH === undefined) delete process.env.MCDEV_INDEX_PARSE_WORKER_PATH;
     else process.env.MCDEV_INDEX_PARSE_WORKER_PATH = ORIG_WORKER_PATH;
     if (ORIG_MARKER === undefined) delete process.env.MCDEV_INDEX_WORKER_MARKER;
     else process.env.MCDEV_INDEX_WORKER_MARKER = ORIG_MARKER;
+    if (ORIG_ARGV_CAPTURE === undefined) delete process.env.MCDEV_ARGV_CAPTURE;
+    else process.env.MCDEV_ARGV_CAPTURE = ORIG_ARGV_CAPTURE;
+    process.execArgv.splice(0, process.execArgv.length, ...ORIG_EXEC_ARGV);
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -162,6 +173,80 @@ public class Worker${i} {
       'test/worker-manifest'
     );
     expect(manifest?.indexerVersion).toBe('ast');
+  }, 20000);
+
+  test('falls back to Tree-sitter when a single-file AST worker keeps crashing', async () => {
+    const workerPath = path.join(tempDir, 'crashing-worker.cjs');
+    fs.writeFileSync(workerPath, `
+process.on('message', () => {
+  process.exit(134);
+});
+`);
+    process.env.MCDEV_INDEX_PARSE_WORKER_PATH = workerPath;
+    process.env.MCDEV_INDEX_WORKER_HEAP_MB = '128';
+    process.env.MCDEV_INDEX_WORKER_RETRY_HEAP_MB = '256';
+    const markerPath = path.join(tempDir, 'fallback-worker-used.txt');
+    process.env.MCDEV_INDEX_WORKER_MARKER = markerPath;
+
+    const pkgDir = path.join(tempDir, 'fallback');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'Fallback.java'), `
+package worker.fallback;
+
+public class Fallback {
+    public int value() { return 1; }
+}
+`);
+
+    const version = `ast-worker-fallback-${Date.now()}`;
+    const result = await buildIndex({
+      minecraftSourceDir: tempDir,
+      fabricApiSourceDir: null,
+      minecraftVersion: version,
+      fabricApiVersion: null,
+    });
+
+    expect(result.totalClasses).toBe(1);
+    const indexed = loadPackageIndex('minecraft', 'worker.fallback', version);
+    expect(indexed?.classes.Fallback).toBeDefined();
+    expect(fs.readFileSync(markerPath, 'utf-8').trim().split('\n')).toHaveLength(1);
+  }, 20000);
+
+  test('does not pass parent heap percentage flags to parse workers', async () => {
+    const workerPath = path.join(tempDir, 'argv-worker.cjs');
+    const argvPath = path.join(tempDir, 'argv.json');
+    fs.writeFileSync(workerPath, `
+const fs = require('fs');
+process.on('message', () => {
+  fs.writeFileSync(process.env.MCDEV_ARGV_CAPTURE, JSON.stringify(process.execArgv));
+  process.send({ type: 'result', parsed: [] }, () => process.exit(0));
+});
+`);
+    process.env.MCDEV_INDEX_PARSE_WORKER_PATH = workerPath;
+    process.env.MCDEV_ARGV_CAPTURE = argvPath;
+    process.env.MCDEV_INDEX_WORKER_HEAP_MB = '256';
+    process.execArgv.push('--max-old-space-size-percentage=75');
+    process.execArgv.push('--max-old-space-size=12345');
+
+    const pkgDir = path.join(tempDir, 'argv');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'Argv.java'), `
+package worker.argv;
+
+public class Argv {}
+`);
+
+    await buildIndex({
+      minecraftSourceDir: tempDir,
+      fabricApiSourceDir: null,
+      minecraftVersion: `ast-worker-argv-${Date.now()}`,
+      fabricApiVersion: null,
+    });
+
+    const childArgv = JSON.parse(fs.readFileSync(argvPath, 'utf-8')) as string[];
+    expect(childArgv).toContain('--max-old-space-size=256');
+    expect(childArgv).not.toContain('--max-old-space-size=12345');
+    expect(childArgv.filter(arg => arg.startsWith('--max-old-space-size-percentage'))).toEqual([]);
   }, 20000);
 });
 

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -98,6 +98,7 @@ describe('AST parser worker index build', () => {
   const ORIG_RETRY_HEAP = process.env.MCDEV_INDEX_WORKER_RETRY_HEAP_MB;
   const ORIG_WORKER_PATH = process.env.MCDEV_INDEX_PARSE_WORKER_PATH;
   const ORIG_MARKER = process.env.MCDEV_INDEX_WORKER_MARKER;
+  const ORIG_SINGLE_FILE_FALLBACK = process.env.MCDEV_INDEX_SINGLE_FILE_FALLBACK;
   const ORIG_ARGV_CAPTURE = process.env.MCDEV_ARGV_CAPTURE;
   const ORIG_EXEC_ARGV = [...process.execArgv];
   const tempDir = path.join(os.tmpdir(), 'mcdev-mcp-ast-worker-' + Date.now());
@@ -129,6 +130,8 @@ describe('AST parser worker index build', () => {
     else process.env.MCDEV_INDEX_PARSE_WORKER_PATH = ORIG_WORKER_PATH;
     if (ORIG_MARKER === undefined) delete process.env.MCDEV_INDEX_WORKER_MARKER;
     else process.env.MCDEV_INDEX_WORKER_MARKER = ORIG_MARKER;
+    if (ORIG_SINGLE_FILE_FALLBACK === undefined) delete process.env.MCDEV_INDEX_SINGLE_FILE_FALLBACK;
+    else process.env.MCDEV_INDEX_SINGLE_FILE_FALLBACK = ORIG_SINGLE_FILE_FALLBACK;
     if (ORIG_ARGV_CAPTURE === undefined) delete process.env.MCDEV_ARGV_CAPTURE;
     else process.env.MCDEV_ARGV_CAPTURE = ORIG_ARGV_CAPTURE;
     process.execArgv.splice(0, process.execArgv.length, ...ORIG_EXEC_ARGV);
@@ -175,7 +178,7 @@ public class Worker${i} {
     expect(manifest?.indexerVersion).toBe('ast');
   }, 20000);
 
-  test('falls back to Tree-sitter when a single-file AST worker keeps crashing', async () => {
+  test('falls back to a lightweight parser when a single-file AST worker keeps crashing', async () => {
     const workerPath = path.join(tempDir, 'crashing-worker.cjs');
     fs.writeFileSync(workerPath, `
 process.on('message', () => {
@@ -185,6 +188,7 @@ process.on('message', () => {
     process.env.MCDEV_INDEX_PARSE_WORKER_PATH = workerPath;
     process.env.MCDEV_INDEX_WORKER_HEAP_MB = '128';
     process.env.MCDEV_INDEX_WORKER_RETRY_HEAP_MB = '256';
+    process.env.MCDEV_INDEX_SINGLE_FILE_FALLBACK = 'regex';
     const markerPath = path.join(tempDir, 'fallback-worker-used.txt');
     process.env.MCDEV_INDEX_WORKER_MARKER = markerPath;
 


### PR DESCRIPTION
## Summary
- fall back to the Tree-sitter parser when a single-file AST worker crashes, before trying the high-heap retry
- strip inherited parent heap flags, including --max-old-space-size-percentage, from parse worker argv
- add worker regression tests for single-file fallback and heap flag filtering

## Root Cause
Issue #33 showed that MCDEV_AST_PARSER=1 could still hit a pathological java-parser file after the worker refactor. The worker isolation capped ordinary batches, but a single generated command source could still crash or stall in java-parser. The reporter's --max-old-space-size-percentage=75 also leaked into worker execArgv, bypassing the intended worker heap cap.

## Validation
- npm run typecheck
- npm run lint (passes with existing unrelated any warnings)
- npm run build
- npm test
- MCDEV_AST_PARSER=1 node dist/cli.js rebuild -v 26.2 -> Indexed 6499 classes in 537 packages
- node dist/cli.js status -v 26.2 -> Indexed and Callgraph present

Fixes #33