### PR TITLE
[codex] Fix DebugBridge connect rejection crash

### DIFF
--- a/src/tools/runtime/session.ts
+++ b/src/tools/runtime/session.ts
@@ -68,11 +68,12 @@ export class BridgeSession {
         // Clear the slot once this attempt settles, regardless of outcome.
         // Retain the early-binding so a concurrent successful attempt can't
         // be cleared by an older failure.
-        attempt.finally(() => {
+        const clearConnectPromise = () => {
             if (this.connectPromise === attempt) {
                 this.connectPromise = null;
             }
-        });
+        };
+        attempt.then(clearConnectPromise, clearConnectPromise);
         return attempt;
     }
 


### PR DESCRIPTION
## Summary

Fixes a runtime MCP server crash when `BridgeSession.connect()` fails to reach DebugBridge.

## Root Cause

`connect()` attached a bare `attempt.finally(...)` to clear the cached in-flight connection promise. When the connect attempt rejected, the original rejection was handled by the tool handler, but the promise returned by `finally()` also rejected and had no handler. Node treated that as an unhandled rejection and exited the MCP server, which surfaced in Codex as `Transport closed`.

## Change

Replace the bare `finally()` cleanup with `attempt.then(clear, clear)` so the cache is cleared on success and failure without creating an unhandled rejected promise.

## Validation

- `npm run build`
- Direct MCP stdio repro: call `mc_connect` with no DebugBridge listener, then call `mc_version`; process exits `0`, stderr is empty, the connect error is returned normally, and the later static call still succeeds.
