### PR TITLE
PR39 follow-up

### DIFF
--- a/src/tools/runtime/session.ts
+++ b/src/tools/runtime/session.ts
@@ -68,12 +68,18 @@ export class BridgeSession {
         // Clear the slot once this attempt settles, regardless of outcome.
         // Retain the early-binding so a concurrent successful attempt can't
         // be cleared by an older failure.
-        const clearConnectPromise = () => {
+        //
+        // Note: this must use `.then(clear, clear)` rather than `.finally(clear)`
+        // because the latter returns a new promise that inherits `attempt`'s
+        // rejection. Without an attached handler Node treats it as unhandled
+        // and terminates the MCP stdio process, surfacing in Codex as
+        // "Transport closed".
+        const clearConnectSlot = () => {
             if (this.connectPromise === attempt) {
                 this.connectPromise = null;
             }
         };
-        attempt.then(clearConnectPromise, clearConnectPromise);
+        attempt.then(clearConnectSlot, clearConnectSlot);
         return attempt;
     }
 

--- a/src/tools/runtime/session.ts
+++ b/src/tools/runtime/session.ts
@@ -68,11 +68,12 @@ export class BridgeSession {
         // Clear the slot once this attempt settles, regardless of outcome.
         // Retain the early-binding so a concurrent successful attempt can't
         // be cleared by an older failure.
-        attempt.finally(() => {
+        const clearConnectPromise = () => {
             if (this.connectPromise === attempt) {
                 this.connectPromise = null;
             }
-        });
+        };
+        attempt.then(clearConnectPromise, clearConnectPromise);
         return attempt;
     }
 

--- a/tests/session-connect-rejection.test.ts
+++ b/tests/session-connect-rejection.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { BridgeSession } from '../src/tools/runtime/session.js';
+
+// Regression test for the connect-rejection crash fixed in this PR.
+//
+// Before the fix, `connect()` attached a bare `attempt.finally(clear)` to clear
+// the cached in-flight promise. When `attempt` rejected, the promise returned by
+// `finally()` also rejected with no attached handler. Node treated that as an
+// unhandled rejection and, on recent versions, terminated the MCP stdio
+// process — which surfaced in Codex as `Transport closed` even though the
+// caller had handled the original rejection.
+//
+// Detection: with the buggy code on a default `unhandled-rejections=throw`
+// Node, the bare `.finally()` chain terminates the test process before Jest can
+// report success, so simply reaching the post-connect assertions below is
+// enough to prove the fix is in place.
+describe('BridgeSession.connect() rejection', () => {
+    let session: BridgeSession | undefined;
+
+    afterEach(() => {
+        session?.disconnect();
+        session = undefined;
+    });
+
+    it('rejects without terminating the host when DebugBridge is unreachable', async () => {
+        session = new BridgeSession();
+        // Pin to a closed, privileged port to guarantee an immediate
+        // ECONNREFUSED rather than the 2s connect timeout.
+        session.setPort(1);
+
+        await expect(session.connect()).rejects.toThrow(/WebSocket error/);
+
+        // Reaching this line proves no unhandled rejection escaped, since
+        // Node's default behaviour would have killed the process.
+    });
+
+    it('clears the cached connect slot after a failure so the next caller retries', async () => {
+        session = new BridgeSession();
+        session.setPort(1);
+
+        await expect(session.connect()).rejects.toThrow();
+
+        // A fresh connect() call after a failure must not return the stale,
+        // already-rejected cached promise. It should issue a new attempt that
+        // also rejects.
+        await expect(session.connect()).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
Follow-up to #39. (I cannot directly edit the PR source repo because permission wasn't granted)

This branch layers two changes on top of temotskipa's fix:

1. Rename clearConnectPromise → clearConnectSlot. The local is a thunk that mutates this.connectPromise, not a promise; the new name reads more clearly at the call site.
2. Add tests/session-connect-rejection.test.ts with two cases:
   - A connect() against a closed port must reject without leaving an unhandled rejection that would terminate the MCP stdio process (the original bug).
   - A second connect() call after a failed attempt must issue a fresh attempt rather than returning the stale rejected promise from the cache.

The first case is the actual regression guard: with the pre-fix attempt.finally(clear) code on Node's default unhandled-rejections=throw, the test process is killed before Jest can report success, so simply reaching the post-connect assertion proves the fix is in place.

Also adds an inline comment in session.ts recording the finally-vs-then(clear,clear) rationale so this doesn't regress.

Verification
- npm test — 124/124 pass (after npm run build for the unrelated indexer.test.ts worker fixture)
- npm run lint — no new errors
- npm run typecheck — clean
- Manually verified the test crashes Node on master's .finally() version

cc @temotskipa