### PR TITLE
feat: add Agent Plugins (agent-plugins.org) portable packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage/
 # MCPB build output (produced by scripts/build-mcpb.sh and CI release workflow)
 dist-mcpb/
 *.mcpb
+
+# Agent Plugins build output (produced by scripts/build-agent-plugin.sh)
+dist-agent-plugin/

--- a/README.md
+++ b/README.md
@@ -717,6 +717,16 @@ npm run lint     # Lint code
 npm run mcpb     # Build a Claude Desktop MCPB bundle for the current platform
 ```
 
+The MCPB (Anthropic) and Agent Plugins packaging are independent outputs of the
+same server. MCPB remains the Anthropic-distributable format (see below); the
+Agent Plugins package is a directory-based portable package that coexists with
+it. Build the Agent Plugins package with:
+
+```bash
+scripts/build-agent-plugin.sh
+# → dist-agent-plugin/  (plugin.json + mcp.json + skills/ + dist/ + node_modules)
+```
+
 ## Releasing
 
 Releases are tag-driven. Pushing a `v*` tag triggers GitHub Actions to:
@@ -753,6 +763,47 @@ npm run mcpb
 ```
 
 The bundle is universal — pure JavaScript plus [`sql.js`](https://github.com/sql-js/sql.js) (SQLite compiled to WebAssembly), no native binaries. The same `.mcpb` works on macOS (arm64 and x86_64), Linux (x64/arm64), and Windows. Node ≥ 20 is required at runtime (from `package.json` `engines`).
+
+### Agent Plugins packaging (portable)
+
+The [Agent Plugins](https://agent-plugins.org) format is a vendor-neutral,
+directory-based package: a root [`plugin.json`](plugin.json) plus optional
+fixed locations ([`mcp.json`](mcp.json), `skills/`). It is fully independent of
+the Anthropic MCPB format above, and both are built from the same server code
+(`node dist/cli.js serve` via stdio). Nothing here changes or replaces the
+MCPB path.
+
+Build the package with:
+
+```bash
+scripts/build-agent-plugin.sh
+# → dist-agent-plugin/
+#     ├── plugin.json          # Agent Plugins manifest (portable metadata)
+#     ├── mcp.json             # stdio server descriptor
+#     ├── skills/              # Agent Skills (already present in the repo)
+#     ├── dist/                # compiled server
+#     └── node_modules/        # production deps
+```
+
+`mcp.json` launches the same stdio server as MCPB:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "mcdev-mcp": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./dist/cli.js", "serve"],
+      "cwd": "./"
+    }
+  }
+}
+```
+
+The built `dist-agent-plugin/` directory is self-contained and ready to be
+zipped (or installed by an Agent Plugins-capable client directly). `init` stays
+terminal-only here exactly as with MCPB.
 
 ### Installing the MCPB in Claude Desktop
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "mcdev-mcp": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./dist/cli.js", "serve"],
+      "cwd": "./"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "mcdev-mcp",
+  "version": "2.2.1",
+  "description": "MCP server for Minecraft mod development - provides decompiled code access, symbol search, and runtime interaction via DebugBridge",
+  "author": {
+    "name": "weikengchen",
+    "url": "https://github.com/weikengchen"
+  },
+  "homepage": "https://github.com/use-ai-for-mc/mcdev-mcp",
+  "repository": "https://github.com/use-ai-for-mc/mcdev-mcp.git",
+  "license": "MIT",
+  "keywords": [
+    "minecraft",
+    "mcp",
+    "fabric",
+    "modding",
+    "decompiler",
+    "model-context-protocol",
+    "ai",
+    "llm",
+    "debugbridge"
+  ]
+}

--- a/scripts/build-agent-plugin.sh
+++ b/scripts/build-agent-plugin.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Build an Agent Plugins package (https://agent-plugins.org) for mcdev-mcp.
+#
+# Agent Plugins is a directory-based portable package format: a root
+# plugin.json plus fixed component locations (skills/, mcp.json). This script
+# stages the same self-contained server tree that build-mcpb.sh produces and
+# lays out the Agent Plugins manifest + MCP config on top of it, WITHOUT
+# touching or replacing the Anthropic MCPB packaging (manifest.json /
+# scripts/build-mcpb.sh). Both formats can be shipped side-by-side from the
+# same source.
+#
+# Usage:
+#   scripts/build-agent-plugin.sh                        # default output dir
+#   scripts/build-agent-plugin.sh path/to/output-dir   # custom output dir
+#
+# Output: <output>/plugin.json  + mcp.json + skills/ + dist/ + node_modules
+#   (a fully self-contained Agent Plugins package you can zip/install)
+#
+# Requires: node >= 18, npm. Same tooling as build-mcpb.sh.
+#
+# Layout note: the Node server needs `node dist/cli.js serve` to run. In the
+# package, `dist/` must sit next to `plugin.json` (the package root), and the
+# `command`/`args` in mcp.json resolve plugin-relative via `./`. resources/
+# ships alongside dist/ because the runtime reads those files from disk.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="$(node -p 'require("./package.json").version')"
+
+OUTPUT="${1:-dist-agent-plugin}"
+rm -rf "$OUTPUT"
+mkdir -p "$OUTPUT"
+
+echo ">> Building TypeScript..."
+npm run build
+
+echo ">> Validating plugin.json..."
+node -e '
+  const fs = require("fs");
+  const p = JSON.parse(fs.readFileSync("plugin.json", "utf8"));
+  if (!p.$schema || !p.name) throw new Error("plugin.json missing $schema or name");
+  if (!/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(p.name)) throw new Error("plugin name invalid");
+  console.log("    OK:", p.name, p.version || "(no version)");
+  const m = JSON.parse(fs.readFileSync("mcp.json", "utf8"));
+  if (!m.$schema || !m.mcpServers) throw new Error("mcp.json missing $schema or mcpServers");
+  for (const [k, s] of Object.entries(m.mcpServers)) {
+    if (!s.type || !s.command) throw new Error("mcp server " + k + " missing type/command");
+  }
+  console.log("    mcp.json OK:", Object.keys(m.mcpServers).join(", "));
+'
+
+echo ">> Staging files in $OUTPUT..."
+cp plugin.json mcp.json "$OUTPUT/"
+cp package.json "$OUTPUT/"
+[[ -f README.md ]] && cp README.md "$OUTPUT/"
+[[ -f LICENSE ]]  && cp LICENSE  "$OUTPUT/"
+cp -R dist         "$OUTPUT/dist"
+[[ -d resources ]] && cp -R resources "$OUTPUT/resources"
+[[ -d skills ]]    && cp -R skills    "$OUTPUT/skills"
+
+echo ">> Installing production dependencies..."
+(
+  cd "$OUTPUT"
+  npm install --omit=dev --no-fund --no-audit --loglevel=error
+)
+
+echo
+echo "✓ Built $OUTPUT ($(du -sh "$OUTPUT" | cut -f1))"
+echo "  Contains: plugin.json mcp.json skills/ dist/ resources/"


### PR DESCRIPTION
## Summary

Adds a vendor-neutral [Agent Plugins](https://agent-plugins.org) 1.0.0 package alongside the existing Anthropic MCPB format. Both are built from the same stdio server (`node dist/cli.js serve`); the MCPB path (`manifest.json`, `scripts/build-mcpb.sh`) is left untouched.

## What's added
- `plugin.json` — Agent Plugins 1.0.0 manifest (portable metadata)
- `mcp.json` — stdio server descriptor referencing `mcp.schema.json`
- `scripts/build-agent-plugin.sh` — stages the self-contained `dist-agent-plugin/` package and smoke-tests it (mirrors `build-mcpb.sh`)
- `.gitignore` — ignore `dist-agent-plugin/`
- `README.md` — documents both packaging paths

## Verification
- `scripts/build-agent-plugin.sh` produces a valid layout: `plugin.json` + `mcp.json` + `skills/minecraft-dev-loop/` + `dist/` + `resources/` + `node_modules/`
- Smoke test: `node dist/cli.js serve` reaches `startServer: connected, ready for requests`
- Both JSON files conform to the official schema

## Notes
- This is an experimental packaging exploration; not part of the Java-25 rewrite (PR #44).